### PR TITLE
docs: add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -47,14 +47,7 @@ assignees: ""
 
 - [ ] Authentication (Clerk sign-in / sign-up / session)
 - [ ] Profile page (avatar, bio, links)
-- [ ] Work experience section
-- [ ] Portfolio / projects section
-- [ ] Interest feature
-- [ ] Image upload
-- [ ] Share profile feature
 - [ ] Convex backend / real-time sync
-- [ ] UI / layout / styling
-- [ ] Other (describe below)
 
 ## Convex & Clerk Details _(if relevant)_
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,78 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behaviour in the Community App
+title: "[BUG] "
+labels: bug
+assignees: ""
+---
+
+## Bug Description
+
+<!-- A clear and concise description of what the bug is. -->
+
+## Steps to Reproduce
+
+<!-- Walk us through exactly how to trigger the bug. Be as specific as possible. -->
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behaviour
+
+<!-- What did you expect to happen? -->
+
+## Actual Behaviour
+
+<!-- What actually happened instead? Include any error messages exactly as they appeared. -->
+
+## Screenshots or Screen Recording
+
+<!-- If applicable, add screenshots or a short screen recording to help explain the problem. -->
+
+## Environment
+
+| Detail          | Value                        |
+| --------------- | ---------------------------- |
+| OS              | e.g. macOS 14, Windows 11    |
+| Browser         | e.g. Chrome 124, Firefox 125 |
+| Node.js version | e.g. v20.11.0                |
+| Bun version     | e.g. 1.3.5                   |
+| Deployment      | Local / Production (Vercel)  |
+
+## Affected Area
+
+<!-- Check all that apply -->
+
+- [ ] Authentication (Clerk sign-in / sign-up / session)
+- [ ] Profile page (avatar, bio, links)
+- [ ] Work experience section
+- [ ] Portfolio / projects section
+- [ ] Interest feature
+- [ ] Image upload
+- [ ] Share profile feature
+- [ ] Convex backend / real-time sync
+- [ ] UI / layout / styling
+- [ ] Other (describe below)
+
+## Convex & Clerk Details _(if relevant)_
+
+<!-- If the bug involves auth or backend data, include any relevant info below.
+     Do NOT share secret keys or sensitive credentials. -->
+
+- Convex deployment region: <!-- e.g. us-east-1 -->
+- Error shown in Convex dashboard: <!-- Yes / No / N/A -->
+- Clerk error code or message: <!-- e.g. "session expired", "Missing publishableKey" -->
+
+## Console Output / Logs
+
+<!-- Paste any relevant browser console errors or terminal output here. -->
+
+```
+paste logs here
+```
+
+## Additional Context
+
+<!-- Anything else that might help us understand or reproduce the issue? -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,64 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement for the Community App
+title: "[FEATURE] "
+labels: enhancement
+assignees: ""
+---
+
+## Summary
+
+<!-- In one or two sentences, describe the feature you'd like to see. -->
+
+## Problem Statement
+
+<!-- What problem does this feature solve? Who experiences it and when?
+     Example: "As a community member, I can't currently display my open-source contributions on my profile,
+     so visitors have no way to see my GitHub activity." -->
+
+## Proposed Solution
+
+<!-- Describe how you'd like this feature to work. Be as specific as you can —
+     include UI placement, user flow, or any behaviour details that matter. -->
+
+## Affected Area
+
+<!-- Check all areas this feature would touch -->
+
+- [ ] Profile page (avatar, bio, links)
+- [ ] Work experience section
+- [ ] Portfolio / projects section
+- [ ] Interest feature
+- [ ] Image upload
+- [ ] Share profile feature
+- [ ] Authentication (Clerk)
+- [ ] Convex backend / data model
+- [ ] UI / layout / styling
+- [ ] New section / page entirely
+- [ ] Other (describe below)
+
+## User Story
+
+<!-- Optional but helpful. Frame the feature from a user's perspective. -->
+
+> As a **[type of user]**, I want to **[do something]** so that **[I can achieve this goal]**.
+
+## Alternatives Considered
+
+<!-- Have you thought of other ways to solve this problem?
+     Why is your proposed solution better? -->
+
+## Mockup / Reference
+
+<!-- Optional. Attach a sketch, wireframe, screenshot, or link to a similar feature
+     in another product that inspired this request. -->
+
+## Additional Context
+
+<!-- Any other context, links, or background that would help the maintainers evaluate this request. -->
+
+## Are you willing to implement this?
+
+- [ ] Yes, I'd like to work on this myself
+- [ ] I can help review or test it
+- [ ] No, I'm just suggesting it

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -26,16 +26,8 @@ assignees: ""
 <!-- Check all areas this feature would touch -->
 
 - [ ] Profile page (avatar, bio, links)
-- [ ] Work experience section
-- [ ] Portfolio / projects section
-- [ ] Interest feature
-- [ ] Image upload
-- [ ] Share profile feature
 - [ ] Authentication (Clerk)
 - [ ] Convex backend / data model
-- [ ] UI / layout / styling
-- [ ] New section / page entirely
-- [ ] Other (describe below)
 
 ## User Story
 

--- a/.github/ISSUE_TEMPLATE/pull_request_template.md
+++ b/.github/ISSUE_TEMPLATE/pull_request_template.md
@@ -1,0 +1,68 @@
+# Summary
+
+<!-- Briefly describe what this PR does and why. One paragraph is enough. -->
+
+## Related Issue
+
+<!-- Link the issue this PR resolves. Use the format below so GitHub auto-closes it on merge. -->
+
+Closes #
+
+<!-- If this PR relates to an issue without closing it, use: Relates to # -->
+
+## Type of Change
+
+<!-- Check the one that applies -->
+
+- [ ] Bug fix (fixes an issue without breaking existing functionality)
+- [ ] New feature (adds functionality without breaking existing behaviour)
+- [ ] Breaking change (existing functionality changes or is removed)
+- [ ] Documentation update (README, CONTRIBUTING, templates, etc.)
+- [ ] Refactor (code restructuring, no behaviour changes)
+- [ ] Test (adding or updating tests only)
+- [ ] Chore (dependency update, config change, tooling)
+
+## What Changed
+
+<!-- List the key changes made in this PR. Be specific enough that a reviewer
+     knows where to look without reading every line. -->
+
+-
+-
+-
+
+## Screenshots / Screen Recording _(UI changes only)_
+
+<!-- If your PR touches any UI — layout, styling, components, profile pages — include
+     before and after screenshots or a short screen recording. PRs with UI changes
+     submitted without visuals may be delayed in review. -->
+
+| Before | After |
+| ------ | ----- |
+|        |       |
+
+## Testing Done
+
+<!-- Describe how you tested your changes locally. -->
+
+- [ ] Ran `bun run round-check` and all checks passed (lint, format, tests, build)
+- [ ] Tested authentication flow (sign in / sign up / session handling)
+- [ ] Tested the specific feature or fix in the browser at `http://localhost:3000`
+- [ ] Verified Convex functions sync correctly (`bunx convex dev` running in parallel)
+- [ ] Added or updated tests where applicable
+
+## Pre-submission Checklist
+
+<!-- Go through this before opening the PR. Unchecked items may block the review. -->
+
+- [ ] My branch is up to date with `upstream/main` (`git fetch upstream && git rebase upstream/main`)
+- [ ] `.env.local` is **not** included in this commit
+- [ ] `bun.lock` is excluded unless this PR intentionally updates dependencies
+- [ ] `convex/` folder changes are discarded unless this PR intentionally modifies backend functions (`git restore convex/`)
+- [ ] My commit messages follow the conventional commit format (`feat:`, `fix:`, `docs:`, etc.)
+- [ ] I have not introduced any new lint or TypeScript errors
+
+## Additional Notes for Reviewers
+
+<!-- Anything the reviewer should know — tricky logic, known limitations,
+     follow-up tasks, or areas you'd like specific feedback on. -->


### PR DESCRIPTION
## Summary
Adds GitHub issue and PR templates as requested in #37.

## What Changed
- Added `.github/ISSUE_TEMPLATE/bug_report.md`
- Added `.github/ISSUE_TEMPLATE/feature_request.md`
- Added `.github/pull_request_template.md`

Closes #37

@owonwo 