### PR TITLE
docs: add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,103 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders of the **Community App** project pledge to make participation in our community a harassment-free experience for everyone — regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socioeconomic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+---
+
+## Our Standards
+
+### ✅ Examples of behaviour that contributes to a positive environment
+
+- Demonstrating empathy and kindness toward other community members
+- Being respectful of differing opinions, viewpoints, and levels of experience
+- Giving and gracefully accepting constructive feedback on code, documentation, and ideas
+- Taking responsibility for our mistakes, apologising to those affected, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the community as a whole
+- Helping newcomers get started and feel welcome — everyone was a beginner once
+- Keeping discussions on issues and pull requests focused, relevant, and professional
+
+### ❌ Examples of unacceptable behaviour
+
+- The use of sexualised language or imagery, and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment of any kind
+- Publishing others' private information — such as a physical or email address — without explicit permission (doxxing)
+- Dismissing or belittling contributions because of someone's experience level
+- Sustained disruption of discussions, issues, or pull request reviews
+- Other conduct which could reasonably be considered inappropriate in a professional or community setting
+
+---
+
+## Scope
+
+This Code of Conduct applies in all community spaces — including the GitHub repository (issues, pull requests, discussions, code reviews, and comments) — and also applies when an individual is officially representing the community in public spaces.
+
+Examples of representing our community include using an official project email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+---
+
+## Enforcement Responsibilities
+
+Community leaders and maintainers are responsible for clarifying and enforcing our standards of acceptable behaviour. They will take appropriate and fair corrective action in response to any behaviour they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+---
+
+## Reporting a Violation
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported to the community maintainers at:
+
+**📧 <joseph.owonwo@gmail.com>**
+
+All reports will be reviewed promptly and investigated with discretion. The privacy and safety of the person who reports an incident will be respected at all times. Maintainers who do not follow or enforce this Code of Conduct in good faith may face consequences as determined by the rest of the project leadership.
+
+---
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines when determining consequences for any action deemed in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact:** Use of inappropriate language or other behaviour deemed unprofessional or unwelcome.
+
+**Consequence:** A private, written warning from community leaders that explains the nature of the violation and why the behaviour was inappropriate. A public apology may be requested.
+
+---
+
+### 2. Warning
+
+**Community Impact:** A violation through a single incident or a series of actions.
+
+**Consequence:** A formal warning with consequences for continued behaviour. No unsolicited interaction with the people involved — including those enforcing the Code of Conduct — for a specified period. This includes avoiding interactions in community spaces as well as external channels like social media.
+
+---
+
+### 3. Temporary Ban
+
+**Community Impact:** A serious violation of community standards, including sustained inappropriate behaviour.
+
+**Consequence:** A temporary ban from any form of interaction or public communication with the community for a specified period. No public or private interaction with the people involved is permitted during this period. Violating these terms may lead to a permanent ban.
+
+---
+
+### 4. Permanent Ban
+
+**Community Impact:** Demonstrating a pattern of violations, harassment of an individual, or aggression toward or disparagement of groups of people.
+
+**Consequence:** A permanent ban from all forms of public interaction within the community.
+
+---
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this Code of Conduct, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq).


### PR DESCRIPTION
## Summary

This PR adds a `CODE_OF_CONDUCT.md` file to the root of the repository as requested in #39. The document establishes clear community standards, defines acceptable and unacceptable behaviour, outlines a four-tier enforcement process, and provides a reporting channel for violations.

Closes #39

## What Changed

- Added `CODE_OF_CONDUCT.md` at the root of the repository

## Approach

The Code of Conduct is adapted from the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html) — the most widely adopted open-source CoC standard, used by projects including Linux, Swift, and Go. It has been tailored to reflect the community-first nature of this project, with standards that account for contributors at varying experience levels.

The document covers:
- **Our Pledge** — an inclusive commitment from all members and contributors
- **Our Standards** — clear examples of both positive and unacceptable behaviour
- **Scope** — applies to all GitHub spaces (issues, PRs, code reviews, comments)
- **Reporting** — a dedicated reporting channel for violations
- **Enforcement Guidelines** — a four-tier consequence ladder (Correction → Warning → Temporary Ban → Permanent Ban)
- **Attribution** — proper credit to the Contributor Covenant v2.1


## Pre-submission Checklist

- [x] File is placed at the root of the repository (`CODE_OF_CONDUCT.md`)
- [x] Branch is up to date with `upstream/main`
- [x] `.env.local` is not included
- [x] Commit follows conventional commit format (`docs: add code of conduct closes #39`)
- [x] No lint or build-breaking changes introduced

@owonwo 