### PR TITLE
profile links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,71 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behaviour in the Community App
+title: "[BUG] "
+labels: bug
+assignees: ""
+---
+
+## Bug Description
+
+<!-- A clear and concise description of what the bug is. -->
+
+## Steps to Reproduce
+
+<!-- Walk us through exactly how to trigger the bug. Be as specific as possible. -->
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behaviour
+
+<!-- What did you expect to happen? -->
+
+## Actual Behaviour
+
+<!-- What actually happened instead? Include any error messages exactly as they appeared. -->
+
+## Screenshots or Screen Recording
+
+<!-- If applicable, add screenshots or a short screen recording to help explain the problem. -->
+
+## Environment
+
+| Detail          | Value                        |
+| --------------- | ---------------------------- |
+| OS              | e.g. macOS 14, Windows 11    |
+| Browser         | e.g. Chrome 124, Firefox 125 |
+| Node.js version | e.g. v20.11.0                |
+| Bun version     | e.g. 1.3.5                   |
+| Deployment      | Local / Production (Vercel)  |
+
+## Affected Area
+
+<!-- Check all that apply -->
+
+- [ ] Authentication (Clerk sign-in / sign-up / session)
+- [ ] Profile page (avatar, bio, links)
+- [ ] Convex backend / real-time sync
+
+## Convex & Clerk Details _(if relevant)_
+
+<!-- If the bug involves auth or backend data, include any relevant info below.
+     Do NOT share secret keys or sensitive credentials. -->
+
+- Convex deployment region: <!-- e.g. us-east-1 -->
+- Error shown in Convex dashboard: <!-- Yes / No / N/A -->
+- Clerk error code or message: <!-- e.g. "session expired", "Missing publishableKey" -->
+
+## Console Output / Logs
+
+<!-- Paste any relevant browser console errors or terminal output here. -->
+
+```
+paste logs here
+```
+
+## Additional Context
+
+<!-- Anything else that might help us understand or reproduce the issue? -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,56 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement for the Community App
+title: "[FEATURE] "
+labels: enhancement
+assignees: ""
+---
+
+## Summary
+
+<!-- In one or two sentences, describe the feature you'd like to see. -->
+
+## Problem Statement
+
+<!-- What problem does this feature solve? Who experiences it and when?
+     Example: "As a community member, I can't currently display my open-source contributions on my profile,
+     so visitors have no way to see my GitHub activity." -->
+
+## Proposed Solution
+
+<!-- Describe how you'd like this feature to work. Be as specific as you can —
+     include UI placement, user flow, or any behaviour details that matter. -->
+
+## Affected Area
+
+<!-- Check all areas this feature would touch -->
+
+- [ ] Profile page (avatar, bio, links)
+- [ ] Authentication (Clerk)
+- [ ] Convex backend / data model
+
+## User Story
+
+<!-- Optional but helpful. Frame the feature from a user's perspective. -->
+
+> As a **[type of user]**, I want to **[do something]** so that **[I can achieve this goal]**.
+
+## Alternatives Considered
+
+<!-- Have you thought of other ways to solve this problem?
+     Why is your proposed solution better? -->
+
+## Mockup / Reference
+
+<!-- Optional. Attach a sketch, wireframe, screenshot, or link to a similar feature
+     in another product that inspired this request. -->
+
+## Additional Context
+
+<!-- Any other context, links, or background that would help the maintainers evaluate this request. -->
+
+## Are you willing to implement this?
+
+- [ ] Yes, I'd like to work on this myself
+- [ ] I can help review or test it
+- [ ] No, I'm just suggesting it

--- a/.github/ISSUE_TEMPLATE/pull_request_template.md
+++ b/.github/ISSUE_TEMPLATE/pull_request_template.md
@@ -1,0 +1,68 @@
+# Summary
+
+<!-- Briefly describe what this PR does and why. One paragraph is enough. -->
+
+## Related Issue
+
+<!-- Link the issue this PR resolves. Use the format below so GitHub auto-closes it on merge. -->
+
+Closes #
+
+<!-- If this PR relates to an issue without closing it, use: Relates to # -->
+
+## Type of Change
+
+<!-- Check the one that applies -->
+
+- [ ] Bug fix (fixes an issue without breaking existing functionality)
+- [ ] New feature (adds functionality without breaking existing behaviour)
+- [ ] Breaking change (existing functionality changes or is removed)
+- [ ] Documentation update (README, CONTRIBUTING, templates, etc.)
+- [ ] Refactor (code restructuring, no behaviour changes)
+- [ ] Test (adding or updating tests only)
+- [ ] Chore (dependency update, config change, tooling)
+
+## What Changed
+
+<!-- List the key changes made in this PR. Be specific enough that a reviewer
+     knows where to look without reading every line. -->
+
+-
+-
+-
+
+## Screenshots / Screen Recording _(UI changes only)_
+
+<!-- If your PR touches any UI — layout, styling, components, profile pages — include
+     before and after screenshots or a short screen recording. PRs with UI changes
+     submitted without visuals may be delayed in review. -->
+
+| Before | After |
+| ------ | ----- |
+|        |       |
+
+## Testing Done
+
+<!-- Describe how you tested your changes locally. -->
+
+- [ ] Ran `bun run round-check` and all checks passed (lint, format, tests, build)
+- [ ] Tested authentication flow (sign in / sign up / session handling)
+- [ ] Tested the specific feature or fix in the browser at `http://localhost:3000`
+- [ ] Verified Convex functions sync correctly (`bunx convex dev` running in parallel)
+- [ ] Added or updated tests where applicable
+
+## Pre-submission Checklist
+
+<!-- Go through this before opening the PR. Unchecked items may block the review. -->
+
+- [ ] My branch is up to date with `upstream/main` (`git fetch upstream && git rebase upstream/main`)
+- [ ] `.env.local` is **not** included in this commit
+- [ ] `bun.lock` is excluded unless this PR intentionally updates dependencies
+- [ ] `convex/` folder changes are discarded unless this PR intentionally modifies backend functions (`git restore convex/`)
+- [ ] My commit messages follow the conventional commit format (`feat:`, `fix:`, `docs:`, etc.)
+- [ ] I have not introduced any new lint or TypeScript errors
+
+## Additional Notes for Reviewers
+
+<!-- Anything the reviewer should know — tricky logic, known limitations,
+     follow-up tasks, or areas you'd like specific feedback on. -->

--- a/app/dashboard/settings/profile/page.tsx
+++ b/app/dashboard/settings/profile/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery } from "convex/react";
-import { useForm } from "react-hook-form";
+import { Globe, Link, Plus, Trash2 } from "lucide-react";
+import { useFieldArray, useForm } from "react-hook-form";
 import { z } from "zod";
 import { Input } from "@/components/ui/input"; // Adjust path as needed
 import {
@@ -11,6 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"; // Adjust path as needed
+import { GitHub, LinkedIn } from "~/components/icons";
 import { Button } from "~/components/ui/button"; // Adjust path as needed
 import {
   Form,
@@ -24,6 +26,44 @@ import {
 import { api } from "~/convex/_generated/api";
 import { useTitles } from "~/hooks/useTitles";
 
+const LINK_TYPES = [
+  {
+    tag: "linkedin",
+    title: "LinkedIn",
+    placeholder: "https://linkedin.com/in/yourname",
+  },
+  {
+    tag: "github",
+    title: "GitHub",
+    placeholder: "https://github.com/yourname",
+  },
+  {
+    tag: "portfolio",
+    title: "Personal Website",
+    placeholder: "https://yourwebsite.com",
+  },
+] as const;
+
+type LinkTag = (typeof LINK_TYPES)[number]["tag"];
+
+const getLinkIcon = (tag: string) => {
+  const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
+    linkedin: LinkedIn,
+    github: GitHub,
+    portfolio: Globe,
+  };
+  return iconMap[tag.toLowerCase()] ?? Link;
+};
+
+const linkSchema = z.object({
+  tag: z.enum(["linkedin", "github", "portfolio"]),
+  title: z.string().min(1),
+  value: z
+    .string()
+    .url({ message: "Please enter a valid URL." })
+    .min(1, { message: "URL is required." }),
+});
+
 const formSchema = z.object({
   firstname: z.string().min(2, {
     message: "First name must be at least 2 characters.",
@@ -36,13 +76,16 @@ const formSchema = z.object({
   }),
   phonenumbers: z.string().optional(), // Can be extended for stricter validation
   title: z.string({}),
+  links: z
+    .array(linkSchema)
+    .max(3, { message: "You can add at most 3 links." }),
 });
 
 export default function Profile() {
   const profile = useQuery(api.profiles.getProfile);
 
   return (
-    <div>
+    <div className="px-2 md:px-4">
       <h1 className="text-4xl font-semibold mb-8">Edit Profile</h1>
 
       {profile ? (
@@ -53,6 +96,7 @@ export default function Profile() {
             email: profile.email,
             phonenumbers: profile.phoneNumbers.join(","),
             title: profile?.title,
+            links: profile.links ?? [],
           }}
         />
       ) : (
@@ -72,6 +116,21 @@ export function ProfileForm({
     resolver: zodResolver(formSchema),
     defaultValues: { ...initialData },
   });
+
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: "links",
+  });
+
+  const usedTags = fields.map((f) => f.tag);
+  const availableLinkTypes = LINK_TYPES.filter(
+    (t) => !usedTags.includes(t.tag),
+  );
+
+  function addLink(tag: LinkTag) {
+    const type = LINK_TYPES.find((t) => t.tag === tag)!;
+    append({ tag, title: type.title, value: "" });
+  }
 
   function onSubmit(values: z.infer<typeof formSchema>) {
     console.log(values);
@@ -166,8 +225,8 @@ export function ProfileForm({
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    {titles.map((title) => (
-                      <SelectItem key={title} value={title}>
+                    {titles?.map((title) => (
+                      <SelectItem key={title._id} value={title._id}>
                         {title.name}
                       </SelectItem>
                     ))}
@@ -178,6 +237,92 @@ export function ProfileForm({
               </FormItem>
             )}
           />
+
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-base font-medium leading-none">
+                  Profile Links
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  Add up to 3 links to your profile.
+                </p>
+              </div>
+
+              {/* Add link dropdown — only rendered when slots remain */}
+              {availableLinkTypes.length > 0 && (
+                <Select onValueChange={(val) => addLink(val as LinkTag)}>
+                  <SelectTrigger className="w-40">
+                    <div className="flex items-center gap-2">
+                      <Plus className="h-4 w-4" />
+                      <span>Add Link</span>
+                    </div>
+                  </SelectTrigger>
+                  <SelectContent align="end">
+                    {availableLinkTypes.map((type) => {
+                      const Icon = getLinkIcon(type.tag);
+                      return (
+                        <SelectItem key={type.tag} value={type.tag}>
+                          <span className="flex items-center gap-2">
+                            <Icon className="h-4 w-4" />
+                            {type.title}
+                          </span>
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
+
+            {/* Rendered link rows */}
+            {fields.length === 0 && (
+              <p className="text-sm text-muted-foreground py-4 text-center border border-dashed rounded-md">
+                No links added yet.
+              </p>
+            )}
+
+            {fields.map((field, index) => {
+              const Icon = getLinkIcon(field.tag);
+              const typeConfig = LINK_TYPES.find((t) => t.tag === field.tag)!;
+
+              return (
+                <div key={field.id} className="flex items-end gap-3">
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border bg-muted">
+                    <Icon className="h-4 w-4 text-muted-foreground" />
+                  </div>
+
+                  <FormField
+                    control={form.control}
+                    name={`links.${index}.value`}
+                    render={({ field: inputField }) => (
+                      <FormItem className="flex-1">
+                        <FormLabel>{typeConfig.title}</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder={typeConfig.placeholder}
+                            {...inputField}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="text-muted-foreground hover:text-destructive"
+                    onClick={() => remove(index)}
+                    aria-label={`Remove ${typeConfig.title} link`}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
 
           <Button type="submit">Save changes</Button>
         </form>

--- a/app/dashboard/settings/profile/page.tsx
+++ b/app/dashboard/settings/profile/page.tsx
@@ -37,16 +37,19 @@ const LINK_TYPES = [
   {
     tag: "linkedin",
     title: "LinkedIn",
-    placeholder: "https://linkedin.com/in/yourname",
+    prefix: "linkedin.com/in/",
+    placeholder: "username",
   },
   {
     tag: "github",
     title: "GitHub",
-    placeholder: "https://github.com/yourname",
+    prefix: "github.com/",
+    placeholder: "username",
   },
   {
     tag: "portfolio",
     title: "Personal Website",
+    prefix: null,
     placeholder: "https://yourwebsite.com",
   },
 ] as const;
@@ -62,6 +65,8 @@ const getLinkIcon = (tag: string) => {
   return iconMap[tag.toLowerCase()] ?? Link;
 };
 
+const usernameOnlyRegex = /^(?!.*(http|https|www\.|\/)).+$/i;
+
 // ─── Schemas ───────────────────────────────────────────────────────────────────
 
 const workExperienceSchema = z.object({
@@ -73,14 +78,36 @@ const workExperienceSchema = z.object({
   isCurrent: z.boolean(),
 });
 
-const linkSchema = z.object({
-  tag: z.enum(["linkedin", "github", "portfolio"]),
-  title: z.string().min(1),
-  value: z
-    .string()
-    .url({ message: "Please enter a valid URL." })
-    .min(1, { message: "URL is required." }),
-});
+const linkSchema = z
+  .object({
+    tag: z.enum(["linkedin", "github", "portfolio"]),
+
+    title: z.string().min(1),
+
+    value: z.string().min(1, {
+      message: "This field is required.",
+    }),
+  })
+  .superRefine((data, ctx) => {
+    if (
+      (data.tag === "github" || data.tag === "linkedin") &&
+      !usernameOnlyRegex.test(data.value)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["value"],
+        message: "Enter only your username, not a full URL.",
+      });
+    }
+
+    if (data.tag === "portfolio" && !z.url().safeParse(data.value).success) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["value"],
+        message: "Please enter a valid URL.",
+      });
+    }
+  });
 
 const formSchema = z.object({
   firstname: z.string().min(2, {
@@ -188,9 +215,11 @@ export function ProfileForm({
     name: "links",
   });
 
-  const usedLinkTags = linkFields.map((f) => f.tag);
+  const watchedLinks = form.watch("links") ?? [];
+
+  const usedTags = watchedLinks.map((f) => f.tag);
   const availableLinkTypes = LINK_TYPES.filter(
-    (t) => !usedLinkTags.includes(t.tag),
+    (t) => !usedTags.includes(t.tag),
   );
 
   function addLink(tag: LinkTag) {
@@ -203,6 +232,16 @@ export function ProfileForm({
     setMessage(null);
 
     try {
+      const normalizedLinks = values.links.map((link) => {
+        const type = LINK_TYPES.find((t) => t.tag === link.tag)!;
+        return {
+          ...link,
+          value: type.prefix
+            ? `https://${type.prefix}${link.value}`
+            : link.value,
+        };
+      });
+
       const phoneNumbers = values.phonenumbers
         ? values.phonenumbers
             .split(",")
@@ -238,7 +277,7 @@ export function ProfileForm({
         profileImage: values.profileImage || null,
         workExperience,
         interests,
-        links: values.links,
+        links: normalizedLinks,
       });
 
       setMessage({ type: "success", text: "Profile updated successfully!" });
@@ -453,54 +492,73 @@ export function ProfileForm({
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              {linkFields.length === 0 ? (
-                <p className="text-sm text-white/60 py-4 text-center border border-dashed border-white/20 rounded-md">
-                  No links added yet. Use "Add Link" to get started.
+              {linkFields.length === 0 && (
+                <p className="text-sm text-muted-foreground py-4 text-center border border-dashed rounded-md">
+                  No links added yet.
                 </p>
-              ) : (
-                linkFields.map((field, index) => {
-                  const Icon = getLinkIcon(field.tag);
-                  const typeConfig = LINK_TYPES.find(
-                    (t) => t.tag === field.tag,
-                  )!;
+              )}
 
-                  return (
-                    <div key={field.id} className="flex items-end gap-3">
-                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-white/10 bg-white/5">
-                        <Icon className="h-4 w-4 text-white/60" />
-                      </div>
+              {linkFields.map((field, index) => {
+                const Icon = getLinkIcon(field.tag);
+                const typeConfig = LINK_TYPES.find((t) => t.tag === field.tag)!;
 
-                      <FormField
-                        control={form.control}
-                        name={`links.${index}.value`}
-                        render={({ field: inputField }) => (
-                          <FormItem className="flex-1">
-                            <FormLabel>{typeConfig.title}</FormLabel>
-                            <FormControl>
+                return (
+                  <div key={field.id} className="flex items-start gap-3">
+                    <div className="mt-6.25 flex h-9 w-9 shrink-0 items-center justify-center rounded-md border bg-muted">
+                      <Icon className="h-4 w-4 text-muted-foreground" />
+                    </div>
+
+                    <FormField
+                      control={form.control}
+                      name={`links.${index}.value`}
+                      render={({ field: inputField }) => (
+                        <FormItem className="flex-1">
+                          <FormLabel>{typeConfig.title}</FormLabel>
+                          <FormControl>
+                            {typeConfig.prefix ? (
+                              <div className="flex items-center rounded-md border overflow-hidden focus-within:ring-1 focus-within:ring-ring">
+                                <span className="px-3 py-2 text-sm text-muted-foreground bg-muted border-r shrink-0">
+                                  {typeConfig.prefix}
+                                </span>
+                                <Input
+                                  className="border-0 rounded-none shadow-none focus-visible:ring-0"
+                                  placeholder={typeConfig.placeholder}
+                                  {...inputField}
+                                  onChange={(e) => {
+                                    inputField.onChange(e);
+
+                                    form.clearErrors(`links.${index}.value`);
+                                  }}
+                                />
+                              </div>
+                            ) : (
                               <Input
                                 placeholder={typeConfig.placeholder}
                                 {...inputField}
                               />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
+                            )}
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
 
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        className="text-white/40 hover:text-red-400 hover:bg-red-500/10"
-                        onClick={() => removeLink(index)}
-                        aria-label={`Remove ${typeConfig.title} link`}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  );
-                })
-              )}
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="text-muted-foreground hover:text-destructive mt-6.25"
+                      onClick={() => {
+                        form.clearErrors(`links.${index}`);
+                        removeLink(index);
+                      }}
+                      aria-label={`Remove ${typeConfig.title} link`}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                );
+              })}
             </CardContent>
           </Card>
 
@@ -525,7 +583,7 @@ export function ProfileForm({
                   }
                   className="group flex items-center bg-white border-gray-300"
                 >
-                  <Plus className="h-4 w-4 text-gray-900 group-hover:mr-2 transition-all flex-shrink-0" />
+                  <Plus className="h-4 w-4 text-gray-900 group-hover:mr-2 transition-all shrink-0" />
                   <span className="max-w-0 overflow-hidden group-hover:max-w-xs transition-all duration-300 ease-in-out whitespace-nowrap text-gray-900">
                     Add Experience
                   </span>
@@ -641,7 +699,7 @@ export function ProfileForm({
                               className="h-4 w-4"
                             />
                           </FormControl>
-                          <FormLabel className="!mt-0">
+                          <FormLabel className="mt-0!">
                             I currently work here
                           </FormLabel>
                         </FormItem>

--- a/app/dashboard/settings/profile/page.tsx
+++ b/app/dashboard/settings/profile/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery } from "convex/react";
-import { Plus, Trash2 } from "lucide-react";
+import { Globe, Link, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { z } from "zod";
@@ -13,6 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { GitHub, LinkedIn } from "~/components/icons";
 import { ImageUpload } from "~/components/profile/image-upload";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
@@ -30,6 +31,39 @@ import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
 import { useTitles } from "~/hooks/useTitles";
 
+// ─── Link types ────────────────────────────────────────────────────────────────
+
+const LINK_TYPES = [
+  {
+    tag: "linkedin",
+    title: "LinkedIn",
+    placeholder: "https://linkedin.com/in/yourname",
+  },
+  {
+    tag: "github",
+    title: "GitHub",
+    placeholder: "https://github.com/yourname",
+  },
+  {
+    tag: "portfolio",
+    title: "Personal Website",
+    placeholder: "https://yourwebsite.com",
+  },
+] as const;
+
+type LinkTag = (typeof LINK_TYPES)[number]["tag"];
+
+const getLinkIcon = (tag: string) => {
+  const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
+    linkedin: LinkedIn,
+    github: GitHub,
+    portfolio: Globe,
+  };
+  return iconMap[tag.toLowerCase()] ?? Link;
+};
+
+// ─── Schemas ───────────────────────────────────────────────────────────────────
+
 const workExperienceSchema = z.object({
   position: z.string().min(1, "Position is required"),
   company: z.string().min(1, "Company is required"),
@@ -37,6 +71,15 @@ const workExperienceSchema = z.object({
   endDate: z.string().optional(),
   description: z.string().optional(),
   isCurrent: z.boolean(),
+});
+
+const linkSchema = z.object({
+  tag: z.enum(["linkedin", "github", "portfolio"]),
+  title: z.string().min(1),
+  value: z
+    .string()
+    .url({ message: "Please enter a valid URL." })
+    .min(1, { message: "URL is required." }),
 });
 
 const formSchema = z.object({
@@ -55,13 +98,18 @@ const formSchema = z.object({
   profileImage: z.string().optional(),
   workExperience: z.array(workExperienceSchema).optional(),
   interests: z.string().optional(), // comma-separated
+  links: z
+    .array(linkSchema)
+    .max(3, { message: "You can add at most 3 links." }),
 });
+
+// ─── Page component ────────────────────────────────────────────────────────────
 
 export default function Profile() {
   const profile = useQuery(api.profiles.getProfile);
 
   return (
-    <div>
+    <div className="px-2 md:px-4">
       <h1 className="text-4xl font-semibold mb-8">Edit Profile</h1>
 
       {profile ? (
@@ -86,6 +134,7 @@ export default function Profile() {
                 isCurrent: exp.endDate === null || exp.endDate === undefined,
               })) || [],
             interests: profile.interests?.join(", ") || "",
+            links: profile.links ?? [],
           }}
         />
       ) : (
@@ -94,6 +143,8 @@ export default function Profile() {
     </div>
   );
 }
+
+// ─── Form component ────────────────────────────────────────────────────────────
 
 export function ProfileForm({
   initialData = {},
@@ -113,13 +164,39 @@ export function ProfileForm({
     defaultValues: {
       ...initialData,
       workExperience: initialData.workExperience || [],
+      links: initialData.links || [],
     },
   });
 
-  const { fields, append, remove } = useFieldArray({
+  // Work experience field array
+  const {
+    fields: workFields,
+    append: appendWork,
+    remove: removeWork,
+  } = useFieldArray({
     control: form.control,
     name: "workExperience",
   });
+
+  // Links field array
+  const {
+    fields: linkFields,
+    append: appendLink,
+    remove: removeLink,
+  } = useFieldArray({
+    control: form.control,
+    name: "links",
+  });
+
+  const usedLinkTags = linkFields.map((f) => f.tag);
+  const availableLinkTypes = LINK_TYPES.filter(
+    (t) => !usedLinkTags.includes(t.tag),
+  );
+
+  function addLink(tag: LinkTag) {
+    const type = LINK_TYPES.find((t) => t.tag === tag)!;
+    appendLink({ tag, title: type.title, value: "" });
+  }
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setIsSubmitting(true);
@@ -161,6 +238,7 @@ export function ProfileForm({
         profileImage: values.profileImage || null,
         workExperience,
         interests,
+        links: values.links,
       });
 
       setMessage({ type: "success", text: "Profile updated successfully!" });
@@ -191,6 +269,7 @@ export function ProfileForm({
             </div>
           )}
 
+          {/* ── Basic Information ─────────────────────────────────────────── */}
           <Card className="bg-blue-500/10 border-white/10">
             <CardHeader>
               <CardTitle className="text-xl text-white">
@@ -343,6 +422,89 @@ export function ProfileForm({
             </CardContent>
           </Card>
 
+          {/* ── Profile Links ─────────────────────────────────────────────── */}
+          <Card className="bg-blue-500/10 border-white/10">
+            <CardHeader>
+              <CardTitle className="text-xl text-white flex items-center justify-between">
+                Profile Links
+                {availableLinkTypes.length > 0 && (
+                  <Select onValueChange={(val) => addLink(val as LinkTag)}>
+                    <SelectTrigger className="w-40">
+                      <div className="flex items-center gap-2">
+                        <Plus className="h-4 w-4" />
+                        <span>Add Link</span>
+                      </div>
+                    </SelectTrigger>
+                    <SelectContent align="end">
+                      {availableLinkTypes.map((type) => {
+                        const Icon = getLinkIcon(type.tag);
+                        return (
+                          <SelectItem key={type.tag} value={type.tag}>
+                            <span className="flex items-center gap-2">
+                              <Icon className="h-4 w-4" />
+                              {type.title}
+                            </span>
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectContent>
+                  </Select>
+                )}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {linkFields.length === 0 ? (
+                <p className="text-sm text-white/60 py-4 text-center border border-dashed border-white/20 rounded-md">
+                  No links added yet. Use "Add Link" to get started.
+                </p>
+              ) : (
+                linkFields.map((field, index) => {
+                  const Icon = getLinkIcon(field.tag);
+                  const typeConfig = LINK_TYPES.find(
+                    (t) => t.tag === field.tag,
+                  )!;
+
+                  return (
+                    <div key={field.id} className="flex items-end gap-3">
+                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-white/10 bg-white/5">
+                        <Icon className="h-4 w-4 text-white/60" />
+                      </div>
+
+                      <FormField
+                        control={form.control}
+                        name={`links.${index}.value`}
+                        render={({ field: inputField }) => (
+                          <FormItem className="flex-1">
+                            <FormLabel>{typeConfig.title}</FormLabel>
+                            <FormControl>
+                              <Input
+                                placeholder={typeConfig.placeholder}
+                                {...inputField}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="text-white/40 hover:text-red-400 hover:bg-red-500/10"
+                        onClick={() => removeLink(index)}
+                        aria-label={`Remove ${typeConfig.title} link`}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  );
+                })
+              )}
+            </CardContent>
+          </Card>
+
+          {/* ── Work Experience ───────────────────────────────────────────── */}
           <Card className="bg-blue-500/10 border-white/10">
             <CardHeader>
               <CardTitle className="text-xl text-white flex items-center justify-between">
@@ -352,7 +514,7 @@ export function ProfileForm({
                   size="sm"
                   variant="outline"
                   onClick={() =>
-                    append({
+                    appendWork({
                       position: "",
                       company: "",
                       startDate: "",
@@ -363,7 +525,7 @@ export function ProfileForm({
                   }
                   className="group flex items-center bg-white border-gray-300"
                 >
-                  <Plus className="h-4 w-4 text-gray-900 group-hover:mr-2 transition-all flex-shrink-0" />
+                  <Plus className="h-4 w-4 text-gray-900 group-hover:mr-2 transition-all shrink-0" />
                   <span className="max-w-0 overflow-hidden group-hover:max-w-xs transition-all duration-300 ease-in-out whitespace-nowrap text-gray-900">
                     Add Experience
                   </span>
@@ -371,13 +533,13 @@ export function ProfileForm({
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-6">
-              {fields.length === 0 ? (
+              {workFields.length === 0 ? (
                 <p className="text-white/60 text-sm text-center py-4">
                   No work experience added yet. Click "Add Experience" to get
                   started.
                 </p>
               ) : (
-                fields.map((field, index) => (
+                workFields.map((field, index) => (
                   <div
                     key={field.id}
                     className="p-4 rounded-lg bg-white/5 border border-white/10 space-y-4"
@@ -390,7 +552,7 @@ export function ProfileForm({
                         type="button"
                         size="sm"
                         variant="ghost"
-                        onClick={() => remove(index)}
+                        onClick={() => removeWork(index)}
                         className="text-red-400 hover:text-red-300 hover:bg-red-500/10"
                       >
                         <Trash2 className="h-4 w-4" />
@@ -479,7 +641,7 @@ export function ProfileForm({
                               className="h-4 w-4"
                             />
                           </FormControl>
-                          <FormLabel className="!mt-0">
+                          <FormLabel className="mt-0!">
                             I currently work here
                           </FormLabel>
                         </FormItem>
@@ -510,7 +672,7 @@ export function ProfileForm({
             </CardContent>
           </Card>
 
-          {/* Interests */}
+          {/* ── Interests ─────────────────────────────────────────────────── */}
           <Card className="bg-blue-500/10 border-white/10">
             <CardHeader>
               <CardTitle className="text-xl text-white">Interests</CardTitle>

--- a/app/dashboard/settings/profile/page.tsx
+++ b/app/dashboard/settings/profile/page.tsx
@@ -525,7 +525,7 @@ export function ProfileForm({
                   }
                   className="group flex items-center bg-white border-gray-300"
                 >
-                  <Plus className="h-4 w-4 text-gray-900 group-hover:mr-2 transition-all shrink-0" />
+                  <Plus className="h-4 w-4 text-gray-900 group-hover:mr-2 transition-all flex-shrink-0" />
                   <span className="max-w-0 overflow-hidden group-hover:max-w-xs transition-all duration-300 ease-in-out whitespace-nowrap text-gray-900">
                     Add Experience
                   </span>
@@ -641,7 +641,7 @@ export function ProfileForm({
                               className="h-4 w-4"
                             />
                           </FormControl>
-                          <FormLabel className="mt-0!">
+                          <FormLabel className="!mt-0">
                             I currently work here
                           </FormLabel>
                         </FormItem>

--- a/convex/profiles.ts
+++ b/convex/profiles.ts
@@ -154,6 +154,15 @@ export const updateProfile = mutation({
       ),
     ),
     interests: v.optional(v.array(v.string())),
+    links: v.optional(
+      v.array(
+        v.object({
+          tag: v.string(),
+          title: v.string(),
+          value: v.string(),
+        }),
+      ),
+    ),
   },
   handler: async (ctx, args) => {
     const authUser = await authComponent.getAuthUser(ctx);


### PR DESCRIPTION
## Summary

Closes #35

Adds a profile links management section to the existing profile edit form at `/dashboard/settings/profile`. Authenticated users can now add, update, and remove links for LinkedIn, GitHub, and their personal website.

---

## Changes

- Extended the profile edit form with a **links** field array managed via `useFieldArray`
- Supports up to 3 link types: `linkedin`, `github`, `portfolio`
- Each link type can only be added once; the "Add Link" dropdown hides already-added types
- URL inputs are validated with Zod (`.url()`) and display inline error messages via `FormMessage`
- Links render with their respective icons (`LinkedIn`, `GitHub`, `Globe`) using a shared `getLinkIcon` helper
- Individual links can be removed with a trash icon button
- Form state is seeded from the existing `profile.links` data via `defaultValues`

---

<img width="2932" height="1160" alt="Screenshot 2026-05-05 170910" src="https://github.com/user-attachments/assets/8650de72-92e7-49a9-a106-eb7967e63769" />
