### PR TITLE
ci: skip env validation and replace deploy with convex typecheck

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -24,13 +24,10 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Convex typecheck
+        run: bun run convex:typecheck
+
       - name: Build application
         env:
-          NODE_ENV: ${{ secrets.NODE_ENV }}
-          CONVEX_DEPLOYMENT: ${{ secrets.CONVEX_DEPLOYMENT }}
-          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
-          SITE_URL: ${{ secrets.SITE_URL }}
-          NEXT_PUBLIC_CONVEX_URL: ${{ secrets.NEXT_PUBLIC_CONVEX_URL }}
-          NEXT_PUBLIC_CONVEX_SITE_URL: ${{ secrets.NEXT_PUBLIC_CONVEX_SITE_URL }}
-          NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
-        run: bun run build:ci
+          SKIP_ENV_VALIDATION: "true"
+        run: bun run build

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -30,9 +30,5 @@ jobs:
       - name: Build application
         env:
           SKIP_ENV_VALIDATION: "true"
-          NEXT_PUBLIC_CONVEX_URL: "https://example.convex.cloud"
-          NEXT_PUBLIC_CONVEX_SITE_URL: "https://example.convex.site"
           CONVEX_SITE_URL: "https://example.convex.site"
-          NEXT_PUBLIC_SITE_URL: "https://example.com"
-          SITE_URL: "https://example.com"
         run: bun run build

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -30,5 +30,5 @@ jobs:
       - name: Build application
         env:
           SKIP_ENV_VALIDATION: "true"
-          CONVEX_SITE_URL: "https://example.convex.site"
+          NEXT_PUBLIC_CONVEX_SITE_URL: "https://example.convex.site"
         run: bun run build

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -30,4 +30,9 @@ jobs:
       - name: Build application
         env:
           SKIP_ENV_VALIDATION: "true"
+          NEXT_PUBLIC_CONVEX_URL: "https://example.convex.cloud"
+          NEXT_PUBLIC_CONVEX_SITE_URL: "https://example.convex.site"
+          CONVEX_SITE_URL: "https://example.convex.site"
+          NEXT_PUBLIC_SITE_URL: "https://example.com"
+          SITE_URL: "https://example.com"
         run: bun run build

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev:backend": "convex dev",
     "dev": "next dev --turbopack",
     "build": "next build",
-    "convex:typecheck": "bunx convex codegen --typecheck=enable",
+    "convex:typecheck": "tsc -p convex --noEmit",
     "start": "next start",
     "commit": "cz",
     "svg:convert": "npx @svgr/cli --icon --typescript --ignore-existing --memo --out-dir ./components/Icons -- public/assets/icons",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev:backend": "convex dev",
     "dev": "next dev --turbopack",
     "build": "next build",
-    "build:ci": "bunx convex deploy --preview-create $GITHUB_HEAD_REF --cmd \"bun run build\"",
+    "convex:typecheck": "bunx convex codegen --typecheck=enable",
     "start": "next start",
     "commit": "cz",
     "svg:convert": "npx @svgr/cli --icon --typescript --ignore-existing --memo --out-dir ./components/Icons -- public/assets/icons",


### PR DESCRIPTION
## Summary
- Skip env validation in CI via `SKIP_ENV_VALIDATION=true`
- Replace preview deploy with `convex codegen --typecheck=enable` so the build check no longer requires `CONVEX_DEPLOY_KEY`
- Split into separate Convex typecheck and Build steps