### PR TITLE
project feeds

### DIFF
--- a/app/_components/LandingProjectCard.tsx
+++ b/app/_components/LandingProjectCard.tsx
@@ -1,14 +1,10 @@
 "use client";
 
+import { Calendar, ExternalLink, Figma, FileText, Github } from "lucide-react";
 import Image from "next/image";
-import { useState, useRef, useEffect } from "react";
-import { ExternalLink, Github, Figma, Calendar, FileText } from "lucide-react";
-import { Doc } from "~/convex/_generated/dataModel";
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-} from "~/components/ui/dialog";
+import { useEffect, useRef, useState } from "react";
+import { Dialog, DialogContent, DialogTitle } from "~/components/ui/dialog";
+import type { Doc } from "~/convex/_generated/dataModel";
 
 type Project = Doc<"project">;
 type MediaItem = Project["media"][number];
@@ -104,7 +100,9 @@ function MediaThumb({
 
   if (!url) {
     return (
-      <div className={`flex items-center justify-center bg-neutral-800 ${className}`}>
+      <div
+        className={`flex items-center justify-center bg-neutral-800 ${className}`}
+      >
         <span className="text-xs uppercase tracking-widest text-neutral-500">
           No Preview
         </span>
@@ -114,9 +112,13 @@ function MediaThumb({
 
   if (isPdf) {
     return (
-      <div className={`flex flex-col items-center justify-center gap-2 bg-neutral-800 ${className}`}>
+      <div
+        className={`flex flex-col items-center justify-center gap-2 bg-neutral-800 ${className}`}
+      >
         <FileText size={28} className="text-neutral-400" />
-        <span className="text-xs text-neutral-500 uppercase tracking-widest">PDF</span>
+        <span className="text-xs text-neutral-500 uppercase tracking-widest">
+          PDF
+        </span>
       </div>
     );
   }
@@ -171,23 +173,18 @@ function ProjectModal({
   open: boolean;
   onClose: () => void;
 }) {
-  const [activeIndex, setActiveIndex] =
-    useState(0);
+  const [activeIndex, setActiveIndex] = useState(0);
 
-  const timelineLabel =
-    getTimelineLabel(project);
+  const timelineLabel = getTimelineLabel(project);
 
   const media = project.media ?? [];
   const links = project.link ?? [];
 
-  const active =
-    media[activeIndex] ?? null;
+  const active = media[activeIndex] ?? null;
 
-  const isVideo =
-    active?.metadata?.mimeType?.startsWith("video/");
+  const isVideo = active?.metadata?.mimeType?.startsWith("video/");
 
-  const isPdf =
-    active?.metadata?.mimeType === "application/pdf";
+  const isPdf = active?.metadata?.mimeType === "application/pdf";
 
   const activeUrl = active?.metadata?.url ?? null;
 
@@ -203,25 +200,14 @@ function ProjectModal({
       videoRef.current?.play().catch(() => {});
     }, 50);
     return () => clearTimeout(id);
-  }, [activeIndex, isVideo, open]);
+  }, [isVideo]);
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(o) =>
-        !o && onClose()
-      }
-    >
-      <DialogContent
-        className="max-w-2xl w-full p-0 gap-0 bg-neutral-900 border-neutral-800 text-white rounded-2xl max-h-[90vh] flex flex-col overflow-hidden"
-      >
-        <DialogTitle className="sr-only">
-          {project.title}
-        </DialogTitle>
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-2xl w-full p-0 gap-0 bg-neutral-900 border-neutral-800 text-white rounded-2xl max-h-[90vh] flex flex-col overflow-hidden">
+        <DialogTitle className="sr-only">{project.title}</DialogTitle>
 
-        <div
-          className="relative w-full bg-neutral-950 shrink-0 max-h-[40vh] min-h-55 overflow-hidden flex items-center justify-center"
-        >
+        <div className="relative w-full bg-neutral-950 shrink-0 max-h-[40vh] min-h-55 overflow-hidden flex items-center justify-center">
           <MediaThumb
             item={active}
             alt={project.title}
@@ -230,9 +216,7 @@ function ProjectModal({
           />
 
           {isVideo && (
-            <div
-              className="absolute top-3 right-3 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/40 backdrop-blur-sm border border-white/10 text-white text-xs"
-            >
+            <div className="absolute top-3 right-3 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/40 backdrop-blur-sm border border-white/10 text-white text-xs">
               <VideoBadgeSvg size={11} />
               Video
             </div>
@@ -252,23 +236,17 @@ function ProjectModal({
         </div>
 
         {media.length > 1 && (
-          <div
-            className="flex gap-2 px-6 pt-4 overflow-x-auto scrollbar-none shrink-0"
-          >
+          <div className="flex gap-2 px-6 pt-4 overflow-x-auto scrollbar-none shrink-0">
             {media.map((item, i) => (
               <button
                 key={item.metadata?.storageId}
                 type="button"
-                onClick={() =>
-                  setActiveIndex(i)
-                }
-                className={`shrink-0 w-16 h-10 rounded-lg overflow-hidden border-2 transition-all duration-200 ${ i === activeIndex ? "border-white/80 opacity-100" : "border-transparent opacity-40 hover:opacity-70" }`}
+                onClick={() => setActiveIndex(i)}
+                className={`shrink-0 w-16 h-10 rounded-lg overflow-hidden border-2 transition-all duration-200 ${i === activeIndex ? "border-white/80 opacity-100" : "border-transparent opacity-40 hover:opacity-70"}`}
               >
                 <MediaThumb
                   item={item}
-                  alt={`${project.title} media ${
-                    i + 1
-                  }`}
+                  alt={`${project.title} media ${i + 1}`}
                   className="w-full h-full object-cover"
                 />
               </button>
@@ -277,64 +255,47 @@ function ProjectModal({
         )}
 
         {/* ── Scrollable Body ── */}
-        <div
-          className="px-6 py-5 space-y-5 overflow-y-auto flex-1"
-        >
-          <div
-            className="flex items-start justify-between gap-4 flex-wrap"
-          >
+        <div className="px-6 py-5 space-y-5 overflow-y-auto flex-1">
+          <div className="flex items-start justify-between gap-4 flex-wrap">
             <div>
               {timelineLabel && (
-                <div
-                  className="flex items-center gap-1.5 text-yellow-300 text-xs uppercase tracking-widest mb-1.5"
-                >
+                <div className="flex items-center gap-1.5 text-yellow-300 text-xs uppercase tracking-widest mb-1.5">
                   <Calendar size={11} />
 
                   {timelineLabel}
                 </div>
               )}
 
-              <h2
-                className="text-lg font-semibold leading-snug tracking-tight text-white"
-              >
+              <h2 className="text-lg font-semibold leading-snug tracking-tight text-white">
                 {project.title}
               </h2>
             </div>
 
             {links.length > 0 && (
               <div className="flex flex-wrap gap-2">
-                {links.map(
-                  (link, i) => {
-                    const {
-                      label,
-                      Icon,
-                    } = getLinkMeta(
-                      link.tag
-                    );
+                {links.map((link) => {
+                  const { label, Icon } = getLinkMeta(link.tag);
 
-                    return (
-                      <a
-                        key={`${link.tag}-${link.value}`}
-                        href={link.value}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/8 hover:bg-white/14 border border-white/10 text-xs text-white/80 hover:text-white transition-colors duration-150"
-                      >
-                        <Icon size={12} />
+                  return (
+                    <a
+                      key={`${link.tag}-${link.value}`}
+                      href={link.value}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/8 hover:bg-white/14 border border-white/10 text-xs text-white/80 hover:text-white transition-colors duration-150"
+                    >
+                      <Icon size={12} />
 
-                        {label}
-                      </a>
-                    );
-                  }
-                )}
+                      {label}
+                    </a>
+                  );
+                })}
               </div>
             )}
           </div>
 
           {project.description && (
-            <p
-              className="text-sm text-neutral-400 leading-relaxed whitespace-pre-line"
-            >
+            <p className="text-sm text-neutral-400 leading-relaxed whitespace-pre-line">
               {project.description}
             </p>
           )}
@@ -346,36 +307,22 @@ function ProjectModal({
 
 // ─── Card ────────────────────────────────────────────────────────────────────
 
-const LandingProjectCard = ({
-  project,
-}: {
-  project: Project;
-}) => {
-  const [modalOpen, setModalOpen] =
-    useState(false);
+const LandingProjectCard = ({ project }: { project: Project }) => {
+  const [modalOpen, setModalOpen] = useState(false);
 
-  const videoRef =
-    useRef<HTMLVideoElement>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
 
-  const firstMedia =
-    project.media?.[0] ?? null;
+  const firstMedia = project.media?.[0] ?? null;
 
-  const mimeType =
-    firstMedia?.metadata?.mimeType ?? "";
+  const mimeType = firstMedia?.metadata?.mimeType ?? "";
 
-  const isVideo =
-    mimeType.startsWith("video/");
+  const isVideo = mimeType.startsWith("video/");
 
-  const isPdf =
-    mimeType === "application/pdf";
+  const isPdf = mimeType === "application/pdf";
 
-  const timelineLabel =
-    getTimelineLabel(project);
+  const timelineLabel = getTimelineLabel(project);
 
-  const liveLink =
-    project.link?.find(
-      (l) => l.tag === "live"
-    )?.value ?? null;
+  const liveLink = project.link?.find((l) => l.tag === "live")?.value ?? null;
 
   return (
     <>
@@ -383,27 +330,16 @@ const LandingProjectCard = ({
         type="button"
         tabIndex={0}
         aria-label={`View ${project.title}`}
-        onClick={() =>
-          setModalOpen(true)
-        }
+        onClick={() => setModalOpen(true)}
         onKeyDown={(e) => {
-          if (
-            e.key === "Enter" ||
-            e.key === " "
-          ) {
+          if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
 
             setModalOpen(true);
           }
         }}
-        onMouseEnter={() =>
-          videoRef.current
-            ?.play()
-            .catch(() => {})
-        }
-        onMouseLeave={() =>
-          videoRef.current?.pause()
-        }
+        onMouseEnter={() => videoRef.current?.play().catch(() => {})}
+        onMouseLeave={() => videoRef.current?.pause()}
         className="group relative overflow-hidden rounded-xl bg-neutral-900 aspect-16/10 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-white/50"
       >
         <div className="absolute inset-0">
@@ -416,55 +352,39 @@ const LandingProjectCard = ({
         </div>
 
         {isVideo && (
-          <div
-            className="absolute top-3 right-3 z-10 flex items-center justify-center w-7 h-7 rounded-full bg-white/10 backdrop-blur-sm border border-white/15 text-white"
-          >
+          <div className="absolute top-3 right-3 z-10 flex items-center justify-center w-7 h-7 rounded-full bg-white/10 backdrop-blur-sm border border-white/15 text-white">
             <VideoBadgeSvg size={13} />
           </div>
         )}
 
         {isPdf && (
-          <div
-            className="absolute top-3 right-3 z-10 flex items-center justify-center w-7 h-7 rounded-full bg-white/10 backdrop-blur-sm border border-white/15 text-white"
-          >
+          <div className="absolute top-3 right-3 z-10 flex items-center justify-center w-7 h-7 rounded-full bg-white/10 backdrop-blur-sm border border-white/15 text-white">
             <FileText size={13} />
           </div>
         )}
 
         {liveLink && (
-          <div
-            className="absolute top-3 left-3 z-10 flex items-center gap-1 px-2.5 py-1 rounded-full bg-black/40 backdrop-blur-sm border border-white/10 text-white/70 text-xs opacity-0 group-hover:opacity-100 transition-opacity duration-200"
-          >
+          <div className="absolute top-3 left-3 z-10 flex items-center gap-1 px-2.5 py-1 rounded-full bg-black/40 backdrop-blur-sm border border-white/10 text-white/70 text-xs opacity-0 group-hover:opacity-100 transition-opacity duration-200">
             <ExternalLink size={10} />
             Live
           </div>
         )}
 
-        <div
-          className="absolute inset-0 bg-linear-to-t from-black/80 via-black/30 to-transparent group-hover:from-black/90 transition-all duration-300"
-        />
+        <div className="absolute inset-0 bg-linear-to-t from-black/80 via-black/30 to-transparent group-hover:from-black/90 transition-all duration-300" />
 
-        <div
-          className="absolute bottom-0 left-0 right-0 z-10 p-4 translate-y-1.5 group-hover:translate-y-0 transition-transform duration-300"
-        >
+        <div className="absolute bottom-0 left-0 right-0 z-10 p-4 translate-y-1.5 group-hover:translate-y-0 transition-transform duration-300">
           {timelineLabel && (
-            <span
-              className="block text-[11px] uppercase tracking-widest text-yellow-300 mb-1"
-            >
+            <span className="block text-[11px] uppercase tracking-widest text-yellow-300 mb-1">
               {timelineLabel}
             </span>
           )}
 
-          <h3
-            className="font-semibold text-sm text-white line-clamp-1"
-          >
+          <h3 className="font-semibold text-sm text-white line-clamp-1">
             {project.title}
           </h3>
 
           {project.description && (
-            <p
-              className="mt-1 text-xs text-white/50 line-clamp-2 max-h-0 opacity-0 group-hover:max-h-10 group-hover:opacity-100 transition-all duration-300 overflow-hidden"
-            >
+            <p className="mt-1 text-xs text-white/50 line-clamp-2 max-h-0 opacity-0 group-hover:max-h-10 group-hover:opacity-100 transition-all duration-300 overflow-hidden">
               {project.description}
             </p>
           )}
@@ -474,9 +394,7 @@ const LandingProjectCard = ({
       <ProjectModal
         project={project}
         open={modalOpen}
-        onClose={() =>
-          setModalOpen(false)
-        }
+        onClose={() => setModalOpen(false)}
       />
     </>
   );

--- a/app/_components/LandingProjectCard.tsx
+++ b/app/_components/LandingProjectCard.tsx
@@ -4,11 +4,7 @@ import Image from "next/image";
 import { useState, useRef, useEffect } from "react";
 import { ExternalLink, Github, Figma, Calendar, FileText } from "lucide-react";
 import { Doc } from "~/convex/_generated/dataModel";
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-} from "~/components/ui/dialog";
+import { Dialog, DialogContent, DialogTitle } from "~/components/ui/dialog";
 
 type Project = Doc<"project">;
 type MediaItem = Project["media"][number];
@@ -104,7 +100,9 @@ function MediaThumb({
 
   if (!url) {
     return (
-      <div className={`flex items-center justify-center bg-neutral-800 ${className}`}>
+      <div
+        className={`flex items-center justify-center bg-neutral-800 ${className}`}
+      >
         <span className="text-xs uppercase tracking-widest text-neutral-500">
           No Preview
         </span>
@@ -114,9 +112,13 @@ function MediaThumb({
 
   if (isPdf) {
     return (
-      <div className={`flex flex-col items-center justify-center gap-2 bg-neutral-800 ${className}`}>
+      <div
+        className={`flex flex-col items-center justify-center gap-2 bg-neutral-800 ${className}`}
+      >
         <FileText size={28} className="text-neutral-400" />
-        <span className="text-xs text-neutral-500 uppercase tracking-widest">PDF</span>
+        <span className="text-xs text-neutral-500 uppercase tracking-widest">
+          PDF
+        </span>
       </div>
     );
   }
@@ -171,23 +173,18 @@ function ProjectModal({
   open: boolean;
   onClose: () => void;
 }) {
-  const [activeIndex, setActiveIndex] =
-    useState(0);
+  const [activeIndex, setActiveIndex] = useState(0);
 
-  const timelineLabel =
-    getTimelineLabel(project);
+  const timelineLabel = getTimelineLabel(project);
 
   const media = project.media ?? [];
   const links = project.link ?? [];
 
-  const active =
-    media[activeIndex] ?? null;
+  const active = media[activeIndex] ?? null;
 
-  const isVideo =
-    active?.metadata?.mimeType?.startsWith("video/");
+  const isVideo = active?.metadata?.mimeType?.startsWith("video/");
 
-  const isPdf =
-    active?.metadata?.mimeType === "application/pdf";
+  const isPdf = active?.metadata?.mimeType === "application/pdf";
 
   const activeUrl = active?.metadata?.url ?? null;
 
@@ -206,22 +203,11 @@ function ProjectModal({
   }, [activeIndex, isVideo, open]);
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(o) =>
-        !o && onClose()
-      }
-    >
-      <DialogContent
-        className="max-w-2xl w-full p-0 gap-0 bg-neutral-900 border-neutral-800 text-white rounded-2xl max-h-[90vh] flex flex-col overflow-hidden"
-      >
-        <DialogTitle className="sr-only">
-          {project.title}
-        </DialogTitle>
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-2xl w-full p-0 gap-0 bg-neutral-900 border-neutral-800 text-white rounded-2xl max-h-[90vh] flex flex-col overflow-hidden">
+        <DialogTitle className="sr-only">{project.title}</DialogTitle>
 
-        <div
-          className="relative w-full bg-neutral-950 shrink-0 max-h-[40vh] min-h-55 overflow-hidden flex items-center justify-center"
-        >
+        <div className="relative w-full bg-neutral-950 shrink-0 max-h-[40vh] min-h-55 overflow-hidden flex items-center justify-center">
           <MediaThumb
             item={active}
             alt={project.title}
@@ -230,9 +216,7 @@ function ProjectModal({
           />
 
           {isVideo && (
-            <div
-              className="absolute top-3 right-3 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/40 backdrop-blur-sm border border-white/10 text-white text-xs"
-            >
+            <div className="absolute top-3 right-3 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/40 backdrop-blur-sm border border-white/10 text-white text-xs">
               <VideoBadgeSvg size={11} />
               Video
             </div>
@@ -252,23 +236,17 @@ function ProjectModal({
         </div>
 
         {media.length > 1 && (
-          <div
-            className="flex gap-2 px-6 pt-4 overflow-x-auto scrollbar-none shrink-0"
-          >
+          <div className="flex gap-2 px-6 pt-4 overflow-x-auto scrollbar-none shrink-0">
             {media.map((item, i) => (
               <button
                 key={item.metadata?.storageId}
                 type="button"
-                onClick={() =>
-                  setActiveIndex(i)
-                }
-                className={`shrink-0 w-16 h-10 rounded-lg overflow-hidden border-2 transition-all duration-200 ${ i === activeIndex ? "border-white/80 opacity-100" : "border-transparent opacity-40 hover:opacity-70" }`}
+                onClick={() => setActiveIndex(i)}
+                className={`shrink-0 w-16 h-10 rounded-lg overflow-hidden border-2 transition-all duration-200 ${i === activeIndex ? "border-white/80 opacity-100" : "border-transparent opacity-40 hover:opacity-70"}`}
               >
                 <MediaThumb
                   item={item}
-                  alt={`${project.title} media ${
-                    i + 1
-                  }`}
+                  alt={`${project.title} media ${i + 1}`}
                   className="w-full h-full object-cover"
                 />
               </button>
@@ -277,64 +255,47 @@ function ProjectModal({
         )}
 
         {/* ── Scrollable Body ── */}
-        <div
-          className="px-6 py-5 space-y-5 overflow-y-auto flex-1"
-        >
-          <div
-            className="flex items-start justify-between gap-4 flex-wrap"
-          >
+        <div className="px-6 py-5 space-y-5 overflow-y-auto flex-1">
+          <div className="flex items-start justify-between gap-4 flex-wrap">
             <div>
               {timelineLabel && (
-                <div
-                  className="flex items-center gap-1.5 text-yellow-300 text-xs uppercase tracking-widest mb-1.5"
-                >
+                <div className="flex items-center gap-1.5 text-yellow-300 text-xs uppercase tracking-widest mb-1.5">
                   <Calendar size={11} />
 
                   {timelineLabel}
                 </div>
               )}
 
-              <h2
-                className="text-lg font-semibold leading-snug tracking-tight text-white"
-              >
+              <h2 className="text-lg font-semibold leading-snug tracking-tight text-white">
                 {project.title}
               </h2>
             </div>
 
             {links.length > 0 && (
               <div className="flex flex-wrap gap-2">
-                {links.map(
-                  (link, i) => {
-                    const {
-                      label,
-                      Icon,
-                    } = getLinkMeta(
-                      link.tag
-                    );
+                {links.map((link, i) => {
+                  const { label, Icon } = getLinkMeta(link.tag);
 
-                    return (
-                      <a
-                        key={`${link.tag}-${link.value}`}
-                        href={link.value}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/8 hover:bg-white/14 border border-white/10 text-xs text-white/80 hover:text-white transition-colors duration-150"
-                      >
-                        <Icon size={12} />
+                  return (
+                    <a
+                      key={`${link.tag}-${link.value}`}
+                      href={link.value}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/8 hover:bg-white/14 border border-white/10 text-xs text-white/80 hover:text-white transition-colors duration-150"
+                    >
+                      <Icon size={12} />
 
-                        {label}
-                      </a>
-                    );
-                  }
-                )}
+                      {label}
+                    </a>
+                  );
+                })}
               </div>
             )}
           </div>
 
           {project.description && (
-            <p
-              className="text-sm text-neutral-400 leading-relaxed whitespace-pre-line"
-            >
+            <p className="text-sm text-neutral-400 leading-relaxed whitespace-pre-line">
               {project.description}
             </p>
           )}
@@ -346,36 +307,22 @@ function ProjectModal({
 
 // ─── Card ────────────────────────────────────────────────────────────────────
 
-const LandingProjectCard = ({
-  project,
-}: {
-  project: Project;
-}) => {
-  const [modalOpen, setModalOpen] =
-    useState(false);
+const LandingProjectCard = ({ project }: { project: Project }) => {
+  const [modalOpen, setModalOpen] = useState(false);
 
-  const videoRef =
-    useRef<HTMLVideoElement>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
 
-  const firstMedia =
-    project.media?.[0] ?? null;
+  const firstMedia = project.media?.[0] ?? null;
 
-  const mimeType =
-    firstMedia?.metadata?.mimeType ?? "";
+  const mimeType = firstMedia?.metadata?.mimeType ?? "";
 
-  const isVideo =
-    mimeType.startsWith("video/");
+  const isVideo = mimeType.startsWith("video/");
 
-  const isPdf =
-    mimeType === "application/pdf";
+  const isPdf = mimeType === "application/pdf";
 
-  const timelineLabel =
-    getTimelineLabel(project);
+  const timelineLabel = getTimelineLabel(project);
 
-  const liveLink =
-    project.link?.find(
-      (l) => l.tag === "live"
-    )?.value ?? null;
+  const liveLink = project.link?.find((l) => l.tag === "live")?.value ?? null;
 
   return (
     <>
@@ -383,27 +330,16 @@ const LandingProjectCard = ({
         type="button"
         tabIndex={0}
         aria-label={`View ${project.title}`}
-        onClick={() =>
-          setModalOpen(true)
-        }
+        onClick={() => setModalOpen(true)}
         onKeyDown={(e) => {
-          if (
-            e.key === "Enter" ||
-            e.key === " "
-          ) {
+          if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
 
             setModalOpen(true);
           }
         }}
-        onMouseEnter={() =>
-          videoRef.current
-            ?.play()
-            .catch(() => {})
-        }
-        onMouseLeave={() =>
-          videoRef.current?.pause()
-        }
+        onMouseEnter={() => videoRef.current?.play().catch(() => {})}
+        onMouseLeave={() => videoRef.current?.pause()}
         className="group relative overflow-hidden rounded-xl bg-neutral-900 aspect-16/10 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-white/50"
       >
         <div className="absolute inset-0">
@@ -416,55 +352,39 @@ const LandingProjectCard = ({
         </div>
 
         {isVideo && (
-          <div
-            className="absolute top-3 right-3 z-10 flex items-center justify-center w-7 h-7 rounded-full bg-white/10 backdrop-blur-sm border border-white/15 text-white"
-          >
+          <div className="absolute top-3 right-3 z-10 flex items-center justify-center w-7 h-7 rounded-full bg-white/10 backdrop-blur-sm border border-white/15 text-white">
             <VideoBadgeSvg size={13} />
           </div>
         )}
 
         {isPdf && (
-          <div
-            className="absolute top-3 right-3 z-10 flex items-center justify-center w-7 h-7 rounded-full bg-white/10 backdrop-blur-sm border border-white/15 text-white"
-          >
+          <div className="absolute top-3 right-3 z-10 flex items-center justify-center w-7 h-7 rounded-full bg-white/10 backdrop-blur-sm border border-white/15 text-white">
             <FileText size={13} />
           </div>
         )}
 
         {liveLink && (
-          <div
-            className="absolute top-3 left-3 z-10 flex items-center gap-1 px-2.5 py-1 rounded-full bg-black/40 backdrop-blur-sm border border-white/10 text-white/70 text-xs opacity-0 group-hover:opacity-100 transition-opacity duration-200"
-          >
+          <div className="absolute top-3 left-3 z-10 flex items-center gap-1 px-2.5 py-1 rounded-full bg-black/40 backdrop-blur-sm border border-white/10 text-white/70 text-xs opacity-0 group-hover:opacity-100 transition-opacity duration-200">
             <ExternalLink size={10} />
             Live
           </div>
         )}
 
-        <div
-          className="absolute inset-0 bg-linear-to-t from-black/80 via-black/30 to-transparent group-hover:from-black/90 transition-all duration-300"
-        />
+        <div className="absolute inset-0 bg-linear-to-t from-black/80 via-black/30 to-transparent group-hover:from-black/90 transition-all duration-300" />
 
-        <div
-          className="absolute bottom-0 left-0 right-0 z-10 p-4 translate-y-1.5 group-hover:translate-y-0 transition-transform duration-300"
-        >
+        <div className="absolute bottom-0 left-0 right-0 z-10 p-4 translate-y-1.5 group-hover:translate-y-0 transition-transform duration-300">
           {timelineLabel && (
-            <span
-              className="block text-[11px] uppercase tracking-widest text-yellow-300 mb-1"
-            >
+            <span className="block text-[11px] uppercase tracking-widest text-yellow-300 mb-1">
               {timelineLabel}
             </span>
           )}
 
-          <h3
-            className="font-semibold text-sm text-white line-clamp-1"
-          >
+          <h3 className="font-semibold text-sm text-white line-clamp-1">
             {project.title}
           </h3>
 
           {project.description && (
-            <p
-              className="mt-1 text-xs text-white/50 line-clamp-2 max-h-0 opacity-0 group-hover:max-h-10 group-hover:opacity-100 transition-all duration-300 overflow-hidden"
-            >
+            <p className="mt-1 text-xs text-white/50 line-clamp-2 max-h-0 opacity-0 group-hover:max-h-10 group-hover:opacity-100 transition-all duration-300 overflow-hidden">
               {project.description}
             </p>
           )}
@@ -474,9 +394,7 @@ const LandingProjectCard = ({
       <ProjectModal
         project={project}
         open={modalOpen}
-        onClose={() =>
-          setModalOpen(false)
-        }
+        onClose={() => setModalOpen(false)}
       />
     </>
   );

--- a/app/_components/LandingProjectCard.tsx
+++ b/app/_components/LandingProjectCard.tsx
@@ -1,0 +1,485 @@
+"use client";
+
+import Image from "next/image";
+import { useState, useRef, useEffect } from "react";
+import { ExternalLink, Github, Figma, Calendar, FileText } from "lucide-react";
+import { Doc } from "~/convex/_generated/dataModel";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "~/components/ui/dialog";
+
+type Project = Doc<"project">;
+type MediaItem = Project["media"][number];
+
+function getTimelineLabel(project: Project): string | null {
+  const start = project.timeline?.start?.year;
+  const end = project.timeline?.end?.year;
+
+  if (!start) return null;
+
+  if (project.ongoing) return `${start} – Present`;
+
+  if (end && end !== start) return `${start} – ${end}`;
+
+  return start;
+}
+
+const LINK_META: Record<
+  string,
+  {
+    label: string;
+    Icon: React.ElementType;
+  }
+> = {
+  live: {
+    label: "Live Site",
+    Icon: ExternalLink,
+  },
+
+  github: {
+    label: "GitHub",
+    Icon: Github,
+  },
+
+  figma: {
+    label: "Figma",
+    Icon: Figma,
+  },
+};
+
+function getLinkMeta(tag: string) {
+  return (
+    LINK_META[tag] ?? {
+      label: tag,
+      Icon: ExternalLink,
+    }
+  );
+}
+
+function VideoBadgeSvg({ size }: { size: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      role="img"
+      aria-label="Video"
+    >
+      <title>Video</title>
+      <path d="M15 12l-6 4V8l6 4z" />
+      <rect
+        x="2"
+        y="3"
+        width="20"
+        height="18"
+        rx="3"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}
+
+function MediaThumb({
+  item,
+  alt,
+  className = "",
+  videoRef,
+  fill = false,
+}: {
+  item: MediaItem | null;
+  alt: string;
+  className?: string;
+  videoRef?: React.RefObject<HTMLVideoElement | null>;
+  fill?: boolean;
+}) {
+  const url = item?.metadata?.url ?? null;
+  const mimeType = item?.metadata?.mimeType ?? "";
+  const isVideo = mimeType.startsWith("video/");
+  const isPdf = mimeType === "application/pdf";
+
+  if (!url) {
+    return (
+      <div className={`flex items-center justify-center bg-neutral-800 ${className}`}>
+        <span className="text-xs uppercase tracking-widest text-neutral-500">
+          No Preview
+        </span>
+      </div>
+    );
+  }
+
+  if (isPdf) {
+    return (
+      <div className={`flex flex-col items-center justify-center gap-2 bg-neutral-800 ${className}`}>
+        <FileText size={28} className="text-neutral-400" />
+        <span className="text-xs text-neutral-500 uppercase tracking-widest">PDF</span>
+      </div>
+    );
+  }
+
+  if (isVideo) {
+    return (
+      <video
+        ref={videoRef}
+        src={url}
+        className={className}
+        muted
+        playsInline
+        loop
+        preload="metadata"
+      />
+    );
+  }
+
+  if (fill) {
+    return (
+      <Image
+        src={url}
+        alt={alt}
+        fill
+        className={className}
+        loading="lazy"
+        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+      />
+    );
+  }
+
+  return (
+    <Image
+      src={url}
+      alt={alt}
+      width={item?.metadata?.width ?? 800}
+      height={item?.metadata?.height ?? 450}
+      className={className}
+      loading="lazy"
+    />
+  );
+}
+
+// ─── Modal ───────────────────────────────────────────────────────────────────
+
+function ProjectModal({
+  project,
+  open,
+  onClose,
+}: {
+  project: Project;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [activeIndex, setActiveIndex] =
+    useState(0);
+
+  const timelineLabel =
+    getTimelineLabel(project);
+
+  const media = project.media ?? [];
+  const links = project.link ?? [];
+
+  const active =
+    media[activeIndex] ?? null;
+
+  const isVideo =
+    active?.metadata?.mimeType?.startsWith("video/");
+
+  const isPdf =
+    active?.metadata?.mimeType === "application/pdf";
+
+  const activeUrl = active?.metadata?.url ?? null;
+
+  // Play video whenever the active item changes or the modal opens.
+  // Use a ref callback so we catch the element even on first render.
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (!isVideo) return;
+    // Small timeout lets the Dialog finish its enter animation so the
+    // video element is reliably in the DOM before we call play().
+    const id = setTimeout(() => {
+      videoRef.current?.play().catch(() => {});
+    }, 50);
+    return () => clearTimeout(id);
+  }, [activeIndex, isVideo, open]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) =>
+        !o && onClose()
+      }
+    >
+      <DialogContent
+        className="max-w-2xl w-full p-0 gap-0 bg-neutral-900 border-neutral-800 text-white rounded-2xl max-h-[90vh] flex flex-col overflow-hidden"
+      >
+        <DialogTitle className="sr-only">
+          {project.title}
+        </DialogTitle>
+
+        <div
+          className="relative w-full bg-neutral-950 shrink-0 max-h-[40vh] min-h-55 overflow-hidden flex items-center justify-center"
+        >
+          <MediaThumb
+            item={active}
+            alt={project.title}
+            className="max-w-full max-h-[40vh] object-contain"
+            videoRef={videoRef}
+          />
+
+          {isVideo && (
+            <div
+              className="absolute top-3 right-3 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/40 backdrop-blur-sm border border-white/10 text-white text-xs"
+            >
+              <VideoBadgeSvg size={11} />
+              Video
+            </div>
+          )}
+
+          {isPdf && activeUrl && (
+            <a
+              href={activeUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="absolute bottom-3 left-1/2 -translate-x-1/2 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/10 hover:bg-white/20 backdrop-blur-sm border border-white/15 text-white text-xs transition-colors duration-150"
+            >
+              <FileText size={11} />
+              Open PDF
+            </a>
+          )}
+        </div>
+
+        {media.length > 1 && (
+          <div
+            className="flex gap-2 px-6 pt-4 overflow-x-auto scrollbar-none shrink-0"
+          >
+            {media.map((item, i) => (
+              <button
+                key={item.metadata?.storageId}
+                type="button"
+                onClick={() =>
+                  setActiveIndex(i)
+                }
+                className={`shrink-0 w-16 h-10 rounded-lg overflow-hidden border-2 transition-all duration-200 ${ i === activeIndex ? "border-white/80 opacity-100" : "border-transparent opacity-40 hover:opacity-70" }`}
+              >
+                <MediaThumb
+                  item={item}
+                  alt={`${project.title} media ${
+                    i + 1
+                  }`}
+                  className="w-full h-full object-cover"
+                />
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* ── Scrollable Body ── */}
+        <div
+          className="px-6 py-5 space-y-5 overflow-y-auto flex-1"
+        >
+          <div
+            className="flex items-start justify-between gap-4 flex-wrap"
+          >
+            <div>
+              {timelineLabel && (
+                <div
+                  className="flex items-center gap-1.5 text-yellow-300 text-xs uppercase tracking-widest mb-1.5"
+                >
+                  <Calendar size={11} />
+
+                  {timelineLabel}
+                </div>
+              )}
+
+              <h2
+                className="text-lg font-semibold leading-snug tracking-tight text-white"
+              >
+                {project.title}
+              </h2>
+            </div>
+
+            {links.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {links.map(
+                  (link, i) => {
+                    const {
+                      label,
+                      Icon,
+                    } = getLinkMeta(
+                      link.tag
+                    );
+
+                    return (
+                      <a
+                        key={`${link.tag}-${link.value}`}
+                        href={link.value}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/8 hover:bg-white/14 border border-white/10 text-xs text-white/80 hover:text-white transition-colors duration-150"
+                      >
+                        <Icon size={12} />
+
+                        {label}
+                      </a>
+                    );
+                  }
+                )}
+              </div>
+            )}
+          </div>
+
+          {project.description && (
+            <p
+              className="text-sm text-neutral-400 leading-relaxed whitespace-pre-line"
+            >
+              {project.description}
+            </p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─── Card ────────────────────────────────────────────────────────────────────
+
+const LandingProjectCard = ({
+  project,
+}: {
+  project: Project;
+}) => {
+  const [modalOpen, setModalOpen] =
+    useState(false);
+
+  const videoRef =
+    useRef<HTMLVideoElement>(null);
+
+  const firstMedia =
+    project.media?.[0] ?? null;
+
+  const mimeType =
+    firstMedia?.metadata?.mimeType ?? "";
+
+  const isVideo =
+    mimeType.startsWith("video/");
+
+  const isPdf =
+    mimeType === "application/pdf";
+
+  const timelineLabel =
+    getTimelineLabel(project);
+
+  const liveLink =
+    project.link?.find(
+      (l) => l.tag === "live"
+    )?.value ?? null;
+
+  return (
+    <>
+      <button
+        type="button"
+        tabIndex={0}
+        aria-label={`View ${project.title}`}
+        onClick={() =>
+          setModalOpen(true)
+        }
+        onKeyDown={(e) => {
+          if (
+            e.key === "Enter" ||
+            e.key === " "
+          ) {
+            e.preventDefault();
+
+            setModalOpen(true);
+          }
+        }}
+        onMouseEnter={() =>
+          videoRef.current
+            ?.play()
+            .catch(() => {})
+        }
+        onMouseLeave={() =>
+          videoRef.current?.pause()
+        }
+        className="group relative overflow-hidden rounded-xl bg-neutral-900 aspect-16/10 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+      >
+        <div className="absolute inset-0">
+          <MediaThumb
+            item={firstMedia}
+            alt={project.title}
+            className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-[1.04]"
+            videoRef={videoRef}
+          />
+        </div>
+
+        {isVideo && (
+          <div
+            className="absolute top-3 right-3 z-10 flex items-center justify-center w-7 h-7 rounded-full bg-white/10 backdrop-blur-sm border border-white/15 text-white"
+          >
+            <VideoBadgeSvg size={13} />
+          </div>
+        )}
+
+        {isPdf && (
+          <div
+            className="absolute top-3 right-3 z-10 flex items-center justify-center w-7 h-7 rounded-full bg-white/10 backdrop-blur-sm border border-white/15 text-white"
+          >
+            <FileText size={13} />
+          </div>
+        )}
+
+        {liveLink && (
+          <div
+            className="absolute top-3 left-3 z-10 flex items-center gap-1 px-2.5 py-1 rounded-full bg-black/40 backdrop-blur-sm border border-white/10 text-white/70 text-xs opacity-0 group-hover:opacity-100 transition-opacity duration-200"
+          >
+            <ExternalLink size={10} />
+            Live
+          </div>
+        )}
+
+        <div
+          className="absolute inset-0 bg-linear-to-t from-black/80 via-black/30 to-transparent group-hover:from-black/90 transition-all duration-300"
+        />
+
+        <div
+          className="absolute bottom-0 left-0 right-0 z-10 p-4 translate-y-1.5 group-hover:translate-y-0 transition-transform duration-300"
+        >
+          {timelineLabel && (
+            <span
+              className="block text-[11px] uppercase tracking-widest text-yellow-300 mb-1"
+            >
+              {timelineLabel}
+            </span>
+          )}
+
+          <h3
+            className="font-semibold text-sm text-white line-clamp-1"
+          >
+            {project.title}
+          </h3>
+
+          {project.description && (
+            <p
+              className="mt-1 text-xs text-white/50 line-clamp-2 max-h-0 opacity-0 group-hover:max-h-10 group-hover:opacity-100 transition-all duration-300 overflow-hidden"
+            >
+              {project.description}
+            </p>
+          )}
+        </div>
+      </button>
+
+      <ProjectModal
+        project={project}
+        open={modalOpen}
+        onClose={() =>
+          setModalOpen(false)
+        }
+      />
+    </>
+  );
+};
+
+export default LandingProjectCard;

--- a/app/_components/ProjectFeed.tsx
+++ b/app/_components/ProjectFeed.tsx
@@ -66,21 +66,23 @@ export default function ProjectFeed() {
         {/* Loading more skeletons */}
         {status === "LoadingMore" && (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
-            {SKELETON_MORE_KEYS.map((k) => <ProjectCardSkeleton key={k} />)}
+            {SKELETON_MORE_KEYS.map((k) => (
+              <ProjectCardSkeleton key={k} />
+            ))}
           </div>
         )}
 
         {/* Empty state */}
         {!isLoading && results.length === 0 && (
           <div className="flex flex-col items-center justify-center py-24 text-neutral-500 gap-2">
-            <p className="text-sm">No projects yet — be the first to add one.</p>
+            <p className="text-sm">
+              No projects yet — be the first to add one.
+            </p>
           </div>
         )}
 
         {/* Scroll trigger */}
-        {canLoadMore && (
-          <ScrollTrigger onVisible={() => loadMore(PAGE_SIZE)} />
-        )}
+        {canLoadMore && <ScrollTrigger onVisible={() => loadMore(PAGE_SIZE)} />}
       </div>
     </section>
   );

--- a/app/_components/ProjectFeed.tsx
+++ b/app/_components/ProjectFeed.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { usePaginatedQuery } from "convex/react";
+import { useEffect, useRef } from "react";
+import { api } from "~/convex/_generated/api";
+
+import LandingProjectCard from "./LandingProjectCard";
+import { ProjectCardSkeleton } from "~/components/dashboard/projects/project-card-skeleton";
+
+const PAGE_SIZE = 12;
+const SKELETON_KEYS = Array.from({ length: PAGE_SIZE }, (_, i) => `sk-${i}`);
+const SKELETON_MORE_KEYS = ["sk-more-0", "sk-more-1", "sk-more-2"];
+
+function ScrollTrigger({ onVisible }: { onVisible: () => void }) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) onVisible();
+      },
+      { rootMargin: "200px" },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [onVisible]);
+
+  return <div ref={ref} aria-hidden="true" />;
+}
+
+export default function ProjectFeed() {
+  const { results, status, loadMore } = usePaginatedQuery(
+    api.project.listAll,
+    {},
+    { initialNumItems: PAGE_SIZE },
+  );
+
+  const isLoading = status === "LoadingFirstPage";
+  const canLoadMore = status === "CanLoadMore";
+
+  return (
+    <section className="py-6 px-6">
+      <div className="max-w-6xl mx-auto">
+        <div className="flex items-baseline justify-between flex-wrap gap-3 mb-12">
+          <h2 className="text-3xl sm:text-4xl font-bold tracking-tight text-white">
+            Community Projects
+          </h2>
+          <p className="text-sm text-neutral-500">
+            Work shipped by members of the community
+          </p>
+        </div>
+
+        {/* Grid */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {isLoading
+            ? SKELETON_KEYS.map((k) => <ProjectCardSkeleton key={k} />)
+            : results.map((project) => (
+                <LandingProjectCard key={project._id} project={project} />
+              ))}
+        </div>
+
+        {/* Loading more skeletons */}
+        {status === "LoadingMore" && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
+            {SKELETON_MORE_KEYS.map((k) => <ProjectCardSkeleton key={k} />)}
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!isLoading && results.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-24 text-neutral-500 gap-2">
+            <p className="text-sm">No projects yet — be the first to add one.</p>
+          </div>
+        )}
+
+        {/* Scroll trigger */}
+        {canLoadMore && (
+          <ScrollTrigger onVisible={() => loadMore(PAGE_SIZE)} />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,9 @@
+import ProjectFeed from "./_components/ProjectFeed";
+
 export default function Home() {
   return (
     <div className="px-5 py-8 md:px-8">
-      <h1>Home Page</h1>
+      <ProjectFeed />
     </div>
   );
 }

--- a/convex/project.ts
+++ b/convex/project.ts
@@ -1,4 +1,4 @@
-import { queryGeneric as query } from "convex/server";
+import { paginationOptsValidator, queryGeneric as query } from "convex/server";
 import { v } from "convex/values";
 import { mutation } from "./_generated/server";
 import { authComponent } from "./auth";
@@ -79,5 +79,15 @@ export const deleteProject = mutation({
       throw new Error("Unauthorized action");
 
     await ctx.db.delete(existingProject._id);
+  },
+});
+
+export const listAll = query({
+  args: { paginationOpts: paginationOptsValidator },
+  handler: async (ctx, { paginationOpts }) => {
+    return await ctx.db
+      .query("project")
+      .order("desc")
+      .paginate(paginationOpts);
   },
 });

--- a/convex/project.ts
+++ b/convex/project.ts
@@ -85,9 +85,6 @@ export const deleteProject = mutation({
 export const listAll = query({
   args: { paginationOpts: paginationOptsValidator },
   handler: async (ctx, { paginationOpts }) => {
-    return await ctx.db
-      .query("project")
-      .order("desc")
-      .paginate(paginationOpts);
+    return await ctx.db.query("project").order("desc").paginate(paginationOpts);
   },
 });


### PR DESCRIPTION
## Summary

Adds a public-facing projects feed to the landing page, fulfilling the requirement for users to browse a catalog of community projects with their media.

Closes #50

---

## Changes

### `convex/project.ts`
- Added `listAll` public query using `paginationOptsValidator` — returns projects ordered by most recent, paginated in batches of 12

### `components/LandingProjectCard.tsx` (new file)
- `LandingProjectCard` — card component rendering project media (image or video), title, timeline label, and a live site pill badge
- `ProjectModal` — detail modal triggered on card click, featuring a main media viewer with prev/next navigation, dot indicators, a thumbnail strip (3+ media items), full description with `whitespace-pre-line` support, and external link buttons (Live, GitHub, Figma)

### `components/ProjectFeed.tsx` (new file)
- `ProjectFeed` — grid section consuming `usePaginatedQuery` against `api.project.listAll`
- Responsive 3-column grid (1-col on mobile, 2-col on tablet)
- Scroll-based infinite loading via `IntersectionObserver` (`Scroll`) with a 200px root margin so the next page loads before the user hits the bottom
- Skeleton loading state on first page and on subsequent loads
- Empty state and end-of-feed indicator

### `app/page.tsx`
- Imported and placed `<ProjectFeed />` in the landing page




---

## Screenshots
<img width="3840" height="2160" alt="Screenshot 2026-05-23 174708" src="https://github.com/user-attachments/assets/43734032-e373-420e-a2c7-64b9e812c136" />
<img width="3840" height="2160" alt="Screenshot 2026-05-23 174732" src="https://github.com/user-attachments/assets/b5627cab-7729-4bdc-a17c-d2241759adf4" />