### PR TITLE
feat(profile): user can manage skills on profile

### DIFF
--- a/app/dashboard/settings/profile/page.tsx
+++ b/app/dashboard/settings/profile/page.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/select";
 import { GitHub, LinkedIn } from "~/components/icons";
 import { ImageUpload } from "~/components/profile/image-upload";
+import { SkillsSelect } from "~/components/profile/skills-select";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import {
@@ -36,6 +37,7 @@ import { Textarea } from "~/components/ui/textarea";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
 import { useTitles } from "~/hooks/useTitles";
+import { safeArray } from "~/lib/data.helpers";
 
 // ─── Link types ────────────────────────────────────────────────────────────────
 
@@ -275,6 +277,7 @@ const formSchema = z.object({
   links: z
     .array(linkSchema)
     .max(3, { message: "You can add at most 3 links." }),
+  skills: z.array(z.string()).optional(), // array of skill IDs
 });
 
 // ─── Page component ────────────────────────────────────────────────────────────
@@ -310,6 +313,7 @@ export default function Profile() {
             interests: profile.interests?.join(", ") || "",
             links:
               profile.links?.map((link) => normalizeLinkForEdit(link)) ?? [],
+            skills: profile.skills || [],
           }}
         />
       ) : (
@@ -327,6 +331,7 @@ export function ProfileForm({
   initialData: Partial<z.infer<typeof formSchema>>;
 }) {
   const { titles } = useTitles();
+  const skills = useQuery(api.skills.listSkills);
   const updateProfile = useMutation(api.profiles.updateProfile);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [message, setMessage] = useState<{
@@ -341,6 +346,7 @@ export function ProfileForm({
       workExperience: initialData.workExperience || [],
       location: initialData.location || { city: "", country: "Nigeria" },
       links: initialData.links || [],
+      skills: initialData.skills || [],
     },
   });
 
@@ -435,6 +441,7 @@ export function ProfileForm({
         interests,
         location: values.location || undefined,
         links: normalizedLinks,
+        skills: (values.skills || []) as Id<"skills">[],
       });
 
       setMessage({ type: "success", text: "Profile updated successfully!" });
@@ -887,6 +894,35 @@ export function ProfileForm({
                   </div>
                 ))
               )}
+            </CardContent>
+          </Card>
+
+          {/*── Skills ─────────────────────────────────────────────────── */}
+          <Card className="bg-blue-500/10 border-white/10">
+            <CardHeader>
+              <CardTitle className="text-xl text-white">Skills</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <FormField
+                control={form.control}
+                name="skills"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Your Skills</FormLabel>
+                    <FormControl>
+                      <SkillsSelect
+                        skills={safeArray(skills)}
+                        value={field.value || []}
+                        onChange={field.onChange}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Select the skills that represent your expertise.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             </CardContent>
           </Card>
 

--- a/app/profile/[username]/page.tsx
+++ b/app/profile/[username]/page.tsx
@@ -322,6 +322,29 @@ export default async function ProfileCard({
             </div>
           )}
 
+          {profile.skills && profile.skills.length > 0 && (
+            <div>
+              <div className="flex items-center gap-2 mb-6">
+                <div className="h-8 w-1 rounded-full bg-linear-to-r from-pink-400 to-purple-400"></div>
+                <h2 className="text-xs font-bold tracking-widest text-white/70 uppercase">
+                  Skills
+                </h2>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {profile.skills.map((skill) => (
+                  <div
+                    key={skill.name}
+                    className="group rounded-xl border border-white/20 bg-linear-to-br from-white/15 to-white/5 px-4 py-1 transition-all hover:border-white/30 hover:shadow-lg"
+                  >
+                    <span className="text-sm font-semibold text-white/95 group-hover:text-cyan-300 transition-colors">
+                      {skill.name}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
           {/* Projects from project table (new) */}
           <Projects userId={currentProfile.userId ?? profile.userId} />
 

--- a/components/profile/skills-select.tsx
+++ b/components/profile/skills-select.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { ChevronDown, X } from "lucide-react";
+import { useState } from "react";
+import { Badge } from "~/components/ui/badge";
+import { Input } from "~/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "~/components/ui/popover";
+import { cn } from "~/lib/utils";
+
+type Skill = {
+  _id: string;
+  name: string;
+};
+
+type SkillsSelectProps = {
+  skills: Skill[];
+  value: string[];
+  onChange: (ids: string[]) => void;
+};
+
+export function SkillsSelect({ skills, value, onChange }: SkillsSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const selectedSkills = skills.filter((s) => value.includes(s._id));
+  const availableSkills = skills.filter(
+    (s) =>
+      !value.includes(s._id) &&
+      s.name.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const addSkill = (id: string) => {
+    onChange([...value, id]);
+  };
+
+  const removeSkill = (id: string) => {
+    onChange(value.filter((v) => v !== id));
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Selected skills */}
+      {selectedSkills.length > 0 ? (
+        <div className="space-y-1.5">
+          <p className="text-xs font-medium text-white/50 uppercase tracking-wider">
+            Selected ({selectedSkills.length})
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {selectedSkills.map((skill) => (
+              <Badge
+                key={skill._id}
+                variant="outline"
+                className="gap-1.5 border-blue-400/40 bg-blue-500/20 pl-3 pr-2 py-1 text-sm text-blue-100"
+              >
+                {skill.name}
+                <button
+                  type="button"
+                  onClick={() => removeSkill(skill._id)}
+                  aria-label={`Remove ${skill.name}`}
+                  className="rounded-full p-0.5 text-blue-300 transition-colors hover:bg-blue-400/30 hover:text-white"
+                >
+                  <X size={12} />
+                </button>
+              </Badge>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <p className="text-sm text-white/40">No skills selected yet.</p>
+      )}
+
+      {/* Dropdown trigger */}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "flex w-full items-center justify-between rounded-md border border-white/20 bg-white/5 px-3 py-2 text-sm text-white/70 transition-colors hover:border-white/30 hover:text-white",
+              open && "border-white/30 text-white",
+            )}
+          >
+            <span>
+              {availableSkills.length === 0 &&
+              selectedSkills.length === skills.length
+                ? "All skills selected"
+                : "Add a skill..."}
+            </span>
+            <ChevronDown
+              size={16}
+              className={cn(
+                "text-white/50 transition-transform",
+                open && "rotate-180",
+              )}
+            />
+          </button>
+        </PopoverTrigger>
+
+        <PopoverContent
+          className="w-(--radix-popover-trigger-width) border-white/20 bg-[#1a1f2e] p-0"
+          align="start"
+        >
+          {/* Search */}
+          <div className="border-b border-white/10 p-2">
+            <Input
+              placeholder="Search skills..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="h-8 border-white/20 bg-white/5 text-sm text-white placeholder:text-white/40"
+            />
+          </div>
+
+          {/* Skill list */}
+          <ul className="max-h-52 overflow-y-auto p-1">
+            {availableSkills.length === 0 ? (
+              <li className="px-3 py-4 text-center text-sm text-white/40">
+                {search
+                  ? `No results for "${search}"`
+                  : "No more skills to add"}
+              </li>
+            ) : (
+              availableSkills.map((skill) => (
+                <li key={skill._id}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      addSkill(skill._id);
+                      setSearch("");
+                    }}
+                    className="w-full rounded-sm px-3 py-2 text-left text-sm text-white/80 transition-colors hover:bg-white/10 hover:text-white"
+                  >
+                    {skill.name}
+                  </button>
+                </li>
+              ))
+            )}
+          </ul>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type * as files from "../files.js";
 import type * as http from "../http.js";
 import type * as profiles from "../profiles.js";
 import type * as project from "../project.js";
+import type * as skills from "../skills.js";
 import type * as titles from "../titles.js";
 import type * as workExperience from "../workExperience.js";
 
@@ -30,6 +31,7 @@ declare const fullApi: ApiFromModules<{
   http: typeof http;
   profiles: typeof profiles;
   project: typeof project;
+  skills: typeof skills;
   titles: typeof titles;
   workExperience: typeof workExperience;
 }>;

--- a/convex/profiles.ts
+++ b/convex/profiles.ts
@@ -1,5 +1,6 @@
 import { queryGeneric as query } from "convex/server";
 import { ConvexError, v } from "convex/values";
+import type { Id } from "./_generated/dataModel";
 import { mutation } from "./_generated/server";
 import { authComponent } from "./auth";
 
@@ -59,7 +60,12 @@ export const getProfileByUsername = query({
     if (!user) return null;
 
     const title = user.title ? await ctx.db.get(user.title) : null;
-    return { ...user, title };
+    const skills = user.skills
+      ? await Promise.all(
+        user.skills.map((skillId: Id<"skills">) => ctx.db.get(skillId)),
+      )
+      : [];
+    return { ...user, title, skills };
   },
 });
 
@@ -130,6 +136,7 @@ export const createProfile = mutation({
       workExperience: [],
       interests: [],
       location: { city: "", country: "Nigeria" },
+      skills: [],
     });
   },
 });
@@ -169,6 +176,7 @@ export const updateProfile = mutation({
         country: v.string(),
       }),
     ),
+    skills: v.optional(v.array(v.id("skills"))),
   },
   handler: async (ctx, args) => {
     const authUser = await authComponent.getAuthUser(ctx);
@@ -196,6 +204,7 @@ export const updateProfile = mutation({
       ...(args.interests !== undefined && { interests: args.interests }),
       ...(args.location !== undefined && { location: args.location }),
       ...(args.links !== undefined && { links: args.links }),
+      ...(args.skills !== undefined && { skills: args.skills }),
     });
 
     return profile._id;

--- a/convex/profiles.ts
+++ b/convex/profiles.ts
@@ -62,8 +62,8 @@ export const getProfileByUsername = query({
     const title = user.title ? await ctx.db.get(user.title) : null;
     const skills = user.skills
       ? await Promise.all(
-        user.skills.map((skillId: Id<"skills">) => ctx.db.get(skillId)),
-      )
+          user.skills.map((skillId: Id<"skills">) => ctx.db.get(skillId)),
+        )
       : [];
     return { ...user, title, skills };
   },

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -114,6 +114,10 @@ const schema = defineSchema({
     description: v.nullable(v.string()),
     color: v.optional(v.string()),
   }),
+  skills: defineTable({
+    name: v.string(),
+    description: v.nullable(v.string()),
+  }),
   profile: defineTable({
     userId: v.optional(v.string()),
     firstName: v.string(),
@@ -129,6 +133,7 @@ const schema = defineSchema({
     workExperience: v.optional(profile_work_experience_schema),
     interests: v.optional(v.array(v.string())),
     location: v.optional(profile_location_schema),
+    skills: v.optional(v.array(v.id("skills"))),
   })
     .index("by_username", ["username"])
     .index("by_userId", ["userId"])

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -1,0 +1,9 @@
+import { queryGeneric as query } from "convex/server";
+
+// Query to list skills
+export const listSkills = query({
+  args: {},
+  async handler(ctx) {
+    return await ctx.db.query("skills").collect();
+  },
+});

--- a/snapshots/skills.jsonl
+++ b/snapshots/skills.jsonl
@@ -1,0 +1,7 @@
+{"name":"React","description":"JavaScript library for building user interfaces"}
+{"name":"TypeScript","description":"Strongly typed programming language that builds on JavaScript"}
+{"name":"Next.js","description":"React framework for production-grade web applications"}
+{"name":"Node.js","description":"JavaScript runtime built on Chrome's V8 engine"}
+{"name":"Python","description":"General-purpose programming language"}
+{"name":"Go","description":"Open source programming language by Google"}
+{"name":"PostgreSQL","description":"Open source relational database system"}

--- a/types/models.ts
+++ b/types/models.ts
@@ -20,6 +20,7 @@ export interface Profile {
   workExperience?: ProfileWorkExperience[];
   interests?: string[];
   location?: ProfileLocation;
+  skills?: Skill[];
 }
 
 export interface ProfileWorkExperience {
@@ -34,6 +35,11 @@ export interface Title {
   name: string;
   description: string | null;
   color?: string;
+}
+
+export interface Skill {
+  name: string;
+  description: string | null;
 }
 
 export interface Link {


### PR DESCRIPTION
# Summary

This PR adds the ability for users to add skills to their profile. A new `skills` table is introduced in the Convex schema, and user profiles now store an array of skill references. The settings page gains a searchable combobox for selecting skills, and the public profile page displays them as tags. A seed file is included to populate the skills table for local development.

Closes  #77 

## Type of Change

- [ ] Bug fix (fixes an issue without breaking existing functionality)
- [x] New feature (adds functionality without breaking existing behaviour)
- [ ] Chore (dependency update, config change, tooling)

## What Changed

- Added `skills` table to Convex schema (`name`, `description`) and `skills` field (`array of skill IDs`) to the `profile` table
- Added `convex/skills.ts` with a `listSkills` query, mirroring the existing `titles` pattern
- Updated `createProfile` mutation to initialise `skills: []` on new profiles
- Updated `updateProfile` mutation to accept and patch `skills` as an array of skill IDs
- Updated `getProfileByUsername` query to resolve skill IDs to full skill objects, consistent with how `title` is resolved
- Added `components/profile/skills-select.tsx` — a searchable combobox with a scrollable dropdown for adding skills and badge chips with remove buttons for selected skills
- Updated `/dashboard/settings/profile` page to include a Skills card wired to `SkillsSelect`
- Updated the public profile page (`/profile/[username]`) to display resolved skills as tags
- Added `Skill` interface to `types/models.ts` and `skills` field to the `Profile` interface
- Added `snapshots/skills.jsonl` with 7 seed entries for local development

## Screenshot

<img width="1419" height="527" alt="Screenshot 2026-06-06 160707" src="https://github.com/user-attachments/assets/a6d8f688-6049-4fef-95ee-1a12f9b0a279" />


## Additional Notes for Reviewers

The `profile` table schema has a new optional `skills` field. Existing profile documents are unaffected since the field is `v.optional(...)` — no migration or reseed is required. 

To populate the skills table for local testing, run:

```bash
npx convex import --table skills snapshots/skills.jsonl
```
