### PR TITLE
feat: add project favourites system and favourites dashboard

### DIFF
--- a/app/_components/FavouriteButton.tsx
+++ b/app/_components/FavouriteButton.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useMutation, useQuery } from "convex/react";
+import { Heart } from "lucide-react";
+import { useCallback, useOptimistic, useTransition } from "react";
+import { api } from "~/convex/_generated/api";
+import type { Id } from "~/convex/_generated/dataModel";
+import { cn } from "~/lib/utils";
+
+interface FavouriteButtonProps {
+  projectId: Id<"project">;
+  /**
+   * "overlay" — square icon-only button that sits in the card hover overlay
+   *             alongside the Eye button. Matches Eye button's size/style.
+   * "card"    — compact pill with heart + count; used inside the project modal.
+   * "inline"  — wider pill with label; used in profile project cards.
+   */
+  variant?: "overlay" | "card" | "inline";
+  className?: string;
+}
+
+export function FavouriteButton({
+  projectId,
+  variant = "card",
+  className,
+}: FavouriteButtonProps) {
+  const data = useQuery(api.favourites.getProjectFavourite, { projectId });
+  const toggleFavourite = useMutation(api.favourites.toggle);
+
+  const isFavourited = data?.isFavourited ?? false;
+  const count = data?.count ?? 0;
+
+  const [optimisticFavourited, setOptimisticFavourited] = useOptimistic(
+    isFavourited,
+    (_prev, next: boolean) => next,
+  );
+  const [optimisticCount, setOptimisticCount] = useOptimistic(
+    count,
+    (_prev, next: number) => next,
+  );
+
+  const [isPending, startTransition] = useTransition();
+
+  const isUnauthenticated = data?.isFavourited === null;
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (isUnauthenticated) return;
+
+      const nextState = !isFavourited;
+      const nextCount = nextState ? count + 1 : Math.max(0, count - 1);
+
+      startTransition(async () => {
+        setOptimisticFavourited(nextState);
+        setOptimisticCount(nextCount);
+        await toggleFavourite({ projectId });
+      });
+    },
+    [
+      isUnauthenticated,
+      isFavourited,
+      count,
+      toggleFavourite,
+      projectId,
+      setOptimisticFavourited,
+      setOptimisticCount,
+    ],
+  );
+
+  const ariaLabel = optimisticFavourited
+    ? "Remove from favourites"
+    : "Add to favourites";
+  const title = isUnauthenticated ? "Sign in to favourite projects" : undefined;
+
+  // ── Overlay variant — matches the Eye button exactly ─────────────────────
+  if (variant === "overlay") {
+    return (
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        aria-pressed={optimisticFavourited}
+        disabled={isPending}
+        onClick={handleClick}
+        title={title}
+        className={cn(
+          "relative flex items-center justify-center w-11 h-11 rounded-full",
+          "backdrop-blur-sm border",
+          "transition-all duration-200 hover:scale-110 active:scale-95 cursor-pointer",
+          optimisticFavourited
+            ? "bg-rose-500/30 border-rose-400/50 text-rose-300"
+            : "bg-white/15 hover:bg-rose-500/25 border-white/25 hover:border-rose-400/50 text-white hover:text-rose-300",
+          isUnauthenticated && "opacity-50 cursor-default hover:scale-100",
+          className,
+        )}
+      >
+        <Heart
+          size={20}
+          className={cn(
+            "transition-all duration-200",
+            optimisticFavourited ? "fill-rose-400 text-rose-400 scale-110" : "",
+          )}
+        />
+        {/* Count badge — floats top-right corner of the button */}
+        {optimisticCount > 0 && (
+          <span className="absolute -top-1.5 -right-1.5 min-w-4.5 h-4.5 px-1 flex items-center justify-center rounded-full bg-rose-500 text-white text-[10px] font-bold leading-none tabular-nums">
+            {optimisticCount}
+          </span>
+        )}
+      </button>
+    );
+  }
+
+  // ── Card variant — compact pill; used inside the project modal ────────────
+  if (variant === "card") {
+    return (
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        aria-pressed={optimisticFavourited}
+        disabled={isPending}
+        onClick={handleClick}
+        title={title}
+        className={cn(
+          "group/fav flex items-center gap-1 rounded-full px-2.5 py-1",
+          "backdrop-blur-sm border transition-all duration-200 select-none cursor-pointer",
+          optimisticFavourited
+            ? "bg-rose-500/30 border-rose-400/50 text-rose-300"
+            : "bg-black/40 border-white/10 text-white/60 hover:text-rose-300 hover:border-rose-400/40 hover:bg-rose-500/20",
+          isUnauthenticated && "opacity-60 cursor-default",
+          className,
+        )}
+      >
+        <Heart
+          size={13}
+          className={cn(
+            "transition-all duration-200",
+            optimisticFavourited
+              ? "fill-rose-400 text-rose-400 scale-110"
+              : "group-hover/fav:fill-rose-400/30",
+          )}
+        />
+        {optimisticCount > 0 && (
+          <span className="text-xs font-semibold tabular-nums leading-none">
+            {optimisticCount}
+          </span>
+        )}
+      </button>
+    );
+  }
+
+  // ── Inline variant — wide pill with label; used in profile project cards ──
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      aria-pressed={optimisticFavourited}
+      disabled={isPending}
+      onClick={handleClick}
+      title={title}
+      className={cn(
+        "flex items-center gap-1.5 rounded-full px-3 py-1.5",
+        "border text-sm font-medium transition-all duration-200 select-none cursor-pointer",
+        optimisticFavourited
+          ? "bg-rose-500/15 border-rose-400/40 text-rose-300"
+          : "bg-white/5 border-white/15 text-white/50 hover:text-rose-300 hover:border-rose-400/30 hover:bg-rose-500/10",
+        isUnauthenticated && "opacity-50 cursor-default",
+        className,
+      )}
+    >
+      <Heart
+        size={15}
+        className={cn(
+          "transition-all duration-200",
+          optimisticFavourited ? "fill-rose-400 text-rose-400" : "",
+        )}
+      />
+      <span className="tabular-nums">
+        {optimisticFavourited ? "Favourited" : "Favourite"}
+        {optimisticCount > 0 && ` · ${optimisticCount}`}
+      </span>
+    </button>
+  );
+}

--- a/app/_components/LandingProjectCard.tsx
+++ b/app/_components/LandingProjectCard.tsx
@@ -1,57 +1,22 @@
 "use client";
 
-import { Calendar, ExternalLink, Figma, FileText, Github } from "lucide-react";
-import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
-import { Dialog, DialogContent, DialogTitle } from "~/components/ui/dialog";
+import { Eye, FileText } from "lucide-react";
+import { useRef, useState } from "react";
+import { FavouriteButton } from "~/app/_components/FavouriteButton";
+import { MediaThumb } from "~/app/_components/MediaThumb";
+import { ProjectModal } from "~/app/_components/ProjectModal";
 import type { Doc } from "~/convex/_generated/dataModel";
 
 type Project = Doc<"project">;
-type MediaItem = Project["media"][number];
 
 function getTimelineLabel(project: Project): string | null {
   const start = project.timeline?.start?.year;
   const end = project.timeline?.end?.year;
 
   if (!start) return null;
-
   if (project.ongoing) return `${start} – Present`;
-
   if (end && end !== start) return `${start} – ${end}`;
-
   return start;
-}
-
-const LINK_META: Record<
-  string,
-  {
-    label: string;
-    Icon: React.ElementType;
-  }
-> = {
-  live: {
-    label: "Live Site",
-    Icon: ExternalLink,
-  },
-
-  github: {
-    label: "GitHub",
-    Icon: Github,
-  },
-
-  figma: {
-    label: "Figma",
-    Icon: Figma,
-  },
-};
-
-function getLinkMeta(tag: string) {
-  return (
-    LINK_META[tag] ?? {
-      label: tag,
-      Icon: ExternalLink,
-    }
-  );
 }
 
 function VideoBadgeSvg({ size }: { size: number }) {
@@ -80,316 +45,91 @@ function VideoBadgeSvg({ size }: { size: number }) {
   );
 }
 
-function MediaThumb({
-  item,
-  alt,
-  className = "",
-  videoRef,
-  fill = false,
-}: {
-  item: MediaItem | null;
-  alt: string;
-  className?: string;
-  videoRef?: React.RefObject<HTMLVideoElement | null>;
-  fill?: boolean;
-}) {
-  const url = item?.metadata?.url ?? null;
-  const mimeType = item?.metadata?.mimeType ?? "";
-  const isVideo = mimeType.startsWith("video/");
-  const isPdf = mimeType === "application/pdf";
-
-  if (!url) {
-    return (
-      <div
-        className={`flex items-center justify-center bg-neutral-800 ${className}`}
-      >
-        <span className="text-xs uppercase tracking-widest text-neutral-500">
-          No Preview
-        </span>
-      </div>
-    );
-  }
-
-  if (isPdf) {
-    return (
-      <div
-        className={`flex flex-col items-center justify-center gap-2 bg-neutral-800 ${className}`}
-      >
-        <FileText size={28} className="text-neutral-400" />
-        <span className="text-xs text-neutral-500 uppercase tracking-widest">
-          PDF
-        </span>
-      </div>
-    );
-  }
-
-  if (isVideo) {
-    return (
-      <video
-        ref={videoRef}
-        src={url}
-        className={className}
-        muted
-        playsInline
-        loop
-        preload="metadata"
-      />
-    );
-  }
-
-  if (fill) {
-    return (
-      <Image
-        src={url}
-        alt={alt}
-        fill
-        className={className}
-        loading="lazy"
-        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-      />
-    );
-  }
-
-  return (
-    <Image
-      src={url}
-      alt={alt}
-      width={item?.metadata?.width ?? 800}
-      height={item?.metadata?.height ?? 450}
-      className={className}
-      loading="lazy"
-    />
-  );
-}
-
-// ─── Modal ───────────────────────────────────────────────────────────────────
-
-function ProjectModal({
-  project,
-  open,
-  onClose,
-}: {
-  project: Project;
-  open: boolean;
-  onClose: () => void;
-}) {
-  const [activeIndex, setActiveIndex] = useState(0);
-
-  const timelineLabel = getTimelineLabel(project);
-
-  const media = project.media ?? [];
-  const links = project.link ?? [];
-
-  const active = media[activeIndex] ?? null;
-
-  const isVideo = active?.metadata?.mimeType?.startsWith("video/");
-
-  const isPdf = active?.metadata?.mimeType === "application/pdf";
-
-  const activeUrl = active?.metadata?.url ?? null;
-
-  // Play video whenever the active item changes or the modal opens.
-  // Use a ref callback so we catch the element even on first render.
-  const videoRef = useRef<HTMLVideoElement>(null);
-
-  useEffect(() => {
-    if (!isVideo) return;
-    // Small timeout lets the Dialog finish its enter animation so the
-    // video element is reliably in the DOM before we call play().
-    const id = setTimeout(() => {
-      videoRef.current?.play().catch(() => {});
-    }, 50);
-    return () => clearTimeout(id);
-  }, [isVideo]);
-
-  return (
-    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="max-w-2xl w-full p-0 gap-0 bg-neutral-900 border-neutral-800 text-white rounded-2xl max-h-[90vh] flex flex-col overflow-hidden">
-        <DialogTitle className="sr-only">{project.title}</DialogTitle>
-
-        <div className="relative w-full bg-neutral-950 shrink-0 max-h-[40vh] min-h-55 overflow-hidden flex items-center justify-center">
-          <MediaThumb
-            item={active}
-            alt={project.title}
-            className="max-w-full max-h-[40vh] object-contain"
-            videoRef={videoRef}
-          />
-
-          {isVideo && (
-            <div className="absolute top-3 right-3 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/40 backdrop-blur-sm border border-white/10 text-white text-xs">
-              <VideoBadgeSvg size={11} />
-              Video
-            </div>
-          )}
-
-          {isPdf && activeUrl && (
-            <a
-              href={activeUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="absolute bottom-3 left-1/2 -translate-x-1/2 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/10 hover:bg-white/20 backdrop-blur-sm border border-white/15 text-white text-xs transition-colors duration-150"
-            >
-              <FileText size={11} />
-              Open PDF
-            </a>
-          )}
-        </div>
-
-        {media.length > 1 && (
-          <div className="flex gap-2 px-6 pt-4 overflow-x-auto scrollbar-none shrink-0">
-            {media.map((item, i) => (
-              <button
-                key={item.metadata?.storageId}
-                type="button"
-                onClick={() => setActiveIndex(i)}
-                className={`shrink-0 w-16 h-10 rounded-lg overflow-hidden border-2 transition-all duration-200 ${i === activeIndex ? "border-white/80 opacity-100" : "border-transparent opacity-40 hover:opacity-70"}`}
-              >
-                <MediaThumb
-                  item={item}
-                  alt={`${project.title} media ${i + 1}`}
-                  className="w-full h-full object-cover"
-                />
-              </button>
-            ))}
-          </div>
-        )}
-
-        {/* ── Scrollable Body ── */}
-        <div className="px-6 py-5 space-y-5 overflow-y-auto flex-1">
-          <div className="flex items-start justify-between gap-4 flex-wrap">
-            <div>
-              {timelineLabel && (
-                <div className="flex items-center gap-1.5 text-yellow-300 text-xs uppercase tracking-widest mb-1.5">
-                  <Calendar size={11} />
-
-                  {timelineLabel}
-                </div>
-              )}
-
-              <h2 className="text-lg font-semibold leading-snug tracking-tight text-white">
-                {project.title}
-              </h2>
-            </div>
-
-            {links.length > 0 && (
-              <div className="flex flex-wrap gap-2">
-                {links.map((link) => {
-                  const { label, Icon } = getLinkMeta(link.tag);
-
-                  return (
-                    <a
-                      key={`${link.tag}-${link.value}`}
-                      href={link.value}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/8 hover:bg-white/14 border border-white/10 text-xs text-white/80 hover:text-white transition-colors duration-150"
-                    >
-                      <Icon size={12} />
-
-                      {label}
-                    </a>
-                  );
-                })}
-              </div>
-            )}
-          </div>
-
-          {project.description && (
-            <p className="text-sm text-neutral-400 leading-relaxed whitespace-pre-line">
-              {project.description}
-            </p>
-          )}
-        </div>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-// ─── Card ────────────────────────────────────────────────────────────────────
-
 const LandingProjectCard = ({ project }: { project: Project }) => {
   const [modalOpen, setModalOpen] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
 
   const videoRef = useRef<HTMLVideoElement>(null);
-
   const firstMedia = project.media?.[0] ?? null;
-
   const mimeType = firstMedia?.metadata?.mimeType ?? "";
-
   const isVideo = mimeType.startsWith("video/");
-
   const isPdf = mimeType === "application/pdf";
-
   const timelineLabel = getTimelineLabel(project);
-
-  const liveLink = project.link?.find((l) => l.tag === "live")?.value ?? null;
 
   return (
     <>
-      <button
-        type="button"
-        tabIndex={0}
-        aria-label={`View ${project.title}`}
-        onClick={() => setModalOpen(true)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-
-            setModalOpen(true);
-          }
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: Container needs hover state for video playback */}
+      <section
+        className="group relative overflow-hidden rounded-xl bg-neutral-900 aspect-video w-full"
+        onMouseEnter={() => {
+          setIsHovered(true);
+          videoRef.current?.play().catch(() => {});
         }}
-        onMouseEnter={() => videoRef.current?.play().catch(() => {})}
-        onMouseLeave={() => videoRef.current?.pause()}
-        className="group relative overflow-hidden rounded-xl bg-neutral-900 aspect-16/10 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+        onMouseLeave={() => {
+          setIsHovered(false);
+          videoRef.current?.pause();
+        }}
       >
         <div className="absolute inset-0">
           <MediaThumb
             item={firstMedia}
             alt={project.title}
+            fill
             className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-[1.04]"
             videoRef={videoRef}
           />
         </div>
 
-        {isVideo && (
-          <div className="absolute top-3 right-3 z-10 flex items-center justify-center w-7 h-7 rounded-full bg-white/10 backdrop-blur-sm border border-white/15 text-white">
-            <VideoBadgeSvg size={13} />
+        {/* ── Static type badge — only shown when NOT hovered ── */}
+        {(isVideo || isPdf) && (
+          <div
+            className={`absolute top-3 right-3 z-10 flex items-center justify-center w-7 h-7 rounded-full
+                        bg-white/10 backdrop-blur-sm border border-white/15 text-white
+                        transition-opacity duration-200
+                        ${isHovered ? "opacity-0 pointer-events-none" : "opacity-100"}`}
+          >
+            {isVideo ? <VideoBadgeSvg size={13} /> : <FileText size={13} />}
           </div>
         )}
 
-        {isPdf && (
-          <div className="absolute top-3 right-3 z-10 flex items-center justify-center w-7 h-7 rounded-full bg-white/10 backdrop-blur-sm border border-white/15 text-white">
-            <FileText size={13} />
-          </div>
-        )}
+        {/* ── Hover overlay ── */}
+        <div
+          className={`absolute inset-0 z-20 flex items-center justify-center gap-3 bg-black/55 backdrop-blur-[2px] transition-opacity duration-250 ${isHovered ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+        >
+          <button
+            type="button"
+            aria-label={`View ${project.title}`}
+            onClick={() => setModalOpen(true)}
+            className="flex items-center justify-center w-11 h-11 rounded-full  bg-white/15 hover:bg-white/25  backdrop-blur-sm border border-white/25 hover:border-white/50  text-white  transition-all duration-200 hover:scale-110 active:scale-95  cursor-pointer"
+          >
+            <Eye size={20} />
+          </button>
 
-        {liveLink && (
-          <div className="absolute top-3 left-3 z-10 flex items-center gap-1 px-2.5 py-1 rounded-full bg-black/40 backdrop-blur-sm border border-white/10 text-white/70 text-xs opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-            <ExternalLink size={10} />
-            Live
-          </div>
-        )}
+          <FavouriteButton projectId={project._id} variant="overlay" />
+        </div>
 
-        <div className="absolute inset-0 bg-linear-to-t from-black/80 via-black/30 to-transparent group-hover:from-black/90 transition-all duration-300" />
+        <div className="absolute inset-0 z-10 bg-linear-to-t from-black/80 via-black/20 to-transparent pointer-events-none" />
 
-        <div className="absolute bottom-0 left-0 right-0 z-10 p-4 translate-y-1.5 group-hover:translate-y-0 transition-transform duration-300">
+        <div
+          className="absolute bottom-0 left-0 right-0 z-10 p-4
+                     translate-y-1 group-hover:translate-y-0
+                     transition-transform duration-300 pointer-events-none"
+        >
           {timelineLabel && (
             <span className="block text-[11px] uppercase tracking-widest text-yellow-300 mb-1">
               {timelineLabel}
             </span>
           )}
-
           <h3 className="font-semibold text-sm text-white line-clamp-1">
             {project.title}
           </h3>
-
           {project.description && (
             <p className="mt-1 text-xs text-white/50 line-clamp-2 max-h-0 opacity-0 group-hover:max-h-10 group-hover:opacity-100 transition-all duration-300 overflow-hidden">
               {project.description}
             </p>
           )}
         </div>
-      </button>
+      </section>
 
       <ProjectModal
         project={project}

--- a/app/_components/MediaThumb.tsx
+++ b/app/_components/MediaThumb.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { FileText } from "lucide-react";
+import Image from "next/image";
+import type { Doc } from "~/convex/_generated/dataModel";
+
+type Project = Doc<"project">;
+export type MediaItem = Project["media"][number];
+
+/**
+ * Shared media renderer — handles photo / video / pdf / empty states.
+ * Used by the landing feed card, the dashboard favourites card, and the
+ * shared project modal so all three stay visually consistent.
+ */
+export function MediaThumb({
+  item,
+  alt,
+  className = "",
+  videoRef,
+  fill = false,
+}: {
+  item: MediaItem | null;
+  alt: string;
+  className?: string;
+  videoRef?: React.RefObject<HTMLVideoElement | null>;
+  fill?: boolean;
+}) {
+  const url = item?.metadata?.url ?? null;
+  const mimeType = item?.metadata?.mimeType ?? "";
+  const isVideo = mimeType.startsWith("video/");
+  const isPdf = mimeType === "application/pdf";
+
+  if (!url) {
+    return (
+      <div
+        className={`flex items-center justify-center bg-neutral-800 ${className}`}
+      >
+        <span className="text-xs uppercase tracking-widest text-neutral-500">
+          No Preview
+        </span>
+      </div>
+    );
+  }
+
+  if (isPdf) {
+    return (
+      <div
+        className={`flex flex-col items-center justify-center gap-2 bg-neutral-800 ${className}`}
+      >
+        <FileText size={28} className="text-neutral-400" />
+        <span className="text-xs text-neutral-500 uppercase tracking-widest">
+          PDF
+        </span>
+      </div>
+    );
+  }
+
+  if (isVideo) {
+    return (
+      <video
+        ref={videoRef}
+        src={url}
+        className={className}
+        muted
+        playsInline
+        loop
+        preload="metadata"
+      />
+    );
+  }
+
+  if (fill) {
+    return (
+      <Image
+        src={url}
+        alt={alt}
+        fill
+        className={className}
+        loading="lazy"
+        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+      />
+    );
+  }
+
+  return (
+    <Image
+      src={url}
+      alt={alt}
+      width={item?.metadata?.width ?? 800}
+      height={item?.metadata?.height ?? 450}
+      className={className}
+      loading="lazy"
+    />
+  );
+}

--- a/app/_components/ProjectModal.tsx
+++ b/app/_components/ProjectModal.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { Calendar, ExternalLink, Figma, FileText, Github } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { FavouriteButton } from "~/app/_components/FavouriteButton";
+import { Dialog, DialogContent, DialogTitle } from "~/components/ui/dialog";
+import type { Doc } from "~/convex/_generated/dataModel";
+import { MediaThumb } from "./MediaThumb";
+
+type Project = Doc<"project">;
+
+function getTimelineLabel(project: Project): string | null {
+  const start = project.timeline?.start?.year;
+  const end = project.timeline?.end?.year;
+
+  if (!start) return null;
+  if (project.ongoing) return `${start} – Present`;
+  if (end && end !== start) return `${start} – ${end}`;
+  return start;
+}
+
+const LINK_META: Record<string, { label: string; Icon: React.ElementType }> = {
+  live: { label: "Live Site", Icon: ExternalLink },
+  github: { label: "GitHub", Icon: Github },
+  figma: { label: "Figma", Icon: Figma },
+};
+
+function getLinkMeta(tag: string) {
+  return LINK_META[tag] ?? { label: tag, Icon: ExternalLink };
+}
+
+function VideoBadgeSvg({ size }: { size: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      role="img"
+      aria-label="Video"
+    >
+      <title>Video</title>
+      <path d="M15 12l-6 4V8l6 4z" />
+      <rect
+        x="2"
+        y="3"
+        width="20"
+        height="18"
+        rx="3"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Shared project detail modal — used by both the landing-page community
+ * feed card and the dashboard Favourites page card.
+ */
+export function ProjectModal({
+  project,
+  open,
+  onClose,
+}: {
+  project: Project;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const timelineLabel = getTimelineLabel(project);
+  const media = project.media ?? [];
+  const links = project.link ?? [];
+  const active = media[activeIndex] ?? null;
+
+  const isVideo = active?.metadata?.mimeType?.startsWith("video/");
+  const isPdf = active?.metadata?.mimeType === "application/pdf";
+  const activeUrl = active?.metadata?.url ?? null;
+
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (!isVideo) return;
+    const id = setTimeout(() => {
+      videoRef.current?.play().catch(() => {});
+    }, 50);
+    return () => clearTimeout(id);
+  }, [isVideo]);
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-2xl w-full p-0 gap-0 bg-neutral-900 border-neutral-800 text-white rounded-2xl max-h-[90vh] flex flex-col overflow-hidden">
+        <DialogTitle className="sr-only">{project.title}</DialogTitle>
+
+        <div className="relative w-full bg-neutral-950 shrink-0 max-h-[40vh] min-h-55 overflow-hidden flex items-center justify-center">
+          <MediaThumb
+            item={active}
+            alt={project.title}
+            className="max-w-full max-h-[40vh] object-contain"
+            videoRef={videoRef}
+          />
+
+          {isVideo && (
+            <div className="absolute top-3 right-3 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/40 backdrop-blur-sm border border-white/10 text-white text-xs">
+              <VideoBadgeSvg size={11} />
+              Video
+            </div>
+          )}
+
+          {isPdf && activeUrl && (
+            <a
+              href={activeUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="absolute bottom-3 left-1/2 -translate-x-1/2 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/10 hover:bg-white/20 backdrop-blur-sm border border-white/15 text-white text-xs transition-colors duration-150"
+            >
+              <FileText size={11} />
+              Open PDF
+            </a>
+          )}
+        </div>
+
+        {media.length > 1 && (
+          <div className="flex gap-2 px-6 pt-4 overflow-x-auto scrollbar-none shrink-0">
+            {media.map((item, i) => (
+              <button
+                key={item.metadata?.storageId ?? i}
+                type="button"
+                onClick={() => setActiveIndex(i)}
+                className={`shrink-0 w-16 h-10 rounded-lg overflow-hidden border-2 transition-all duration-200 ${
+                  i === activeIndex
+                    ? "border-white/80 opacity-100"
+                    : "border-transparent opacity-40 hover:opacity-70"
+                }`}
+              >
+                <MediaThumb
+                  item={item}
+                  alt={`${project.title} media ${i + 1}`}
+                  className="w-full h-full object-cover"
+                />
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Scrollable body */}
+        <div className="px-6 py-5 space-y-5 overflow-y-auto flex-1">
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <div>
+              {timelineLabel && (
+                <div className="flex items-center gap-1.5 text-yellow-300 text-xs uppercase tracking-widest mb-1.5">
+                  <Calendar size={11} />
+                  {timelineLabel}
+                </div>
+              )}
+              <h2 className="text-lg font-semibold leading-snug tracking-tight text-white">
+                {project.title}
+              </h2>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <FavouriteButton
+                projectId={project._id}
+                variant="card"
+                className="border-white/20 bg-white/8 hover:bg-rose-500/20"
+              />
+
+              {links.map((link) => {
+                const { label, Icon } = getLinkMeta(link.tag);
+                return (
+                  <a
+                    key={`${link.tag}-${link.value}`}
+                    href={link.value}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/8 hover:bg-white/14 border border-white/10 text-xs text-white/80 hover:text-white transition-colors duration-150"
+                  >
+                    <Icon size={12} />
+                    {label}
+                  </a>
+                );
+              })}
+            </div>
+          </div>
+
+          {project.description && (
+            <p className="text-sm text-neutral-400 leading-relaxed whitespace-pre-line">
+              {project.description}
+            </p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/dashboard/_components/Sidebar.tsx
+++ b/app/dashboard/_components/Sidebar.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from "convex/react";
 import {
   FolderOpenDot,
+  Heart,
   Home,
   LogOut,
   Menu,
@@ -24,6 +25,7 @@ const navigation = [
   { name: "Home", href: "/dashboard/home", icon: Home },
   { name: "Profile", href: "/dashboard/profile", icon: User },
   { name: "Projects", href: "/dashboard/projects", icon: FolderOpenDot },
+  { name: "Favourites", href: "/dashboard/favourites", icon: Heart },
   { name: "Settings", href: "/dashboard/settings", icon: Settings },
 ];
 

--- a/app/dashboard/favourites/_components/FavouritedProjectCard.tsx
+++ b/app/dashboard/favourites/_components/FavouritedProjectCard.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { Eye, FileText } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { useRef, useState } from "react";
+import { FavouriteButton } from "~/app/_components/FavouriteButton";
+import { ProjectModal } from "~/app/_components/ProjectModal";
+
+import type { Doc } from "~/convex/_generated/dataModel";
+
+type FavouritedProject = Doc<"project"> & {
+  favouritedAt: number;
+  owner: {
+    firstName: string;
+    lastName: string;
+    username: string;
+    profileImage: string | null;
+  } | null;
+};
+
+export function FavouritedProjectCard({
+  project,
+}: {
+  project: FavouritedProject;
+}) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  const firstMedia = project.media?.[0] ?? null;
+  const mimeType = firstMedia?.metadata?.mimeType ?? "";
+  const isVideo = mimeType.startsWith("video/");
+  const isPdf = mimeType === "application/pdf";
+  const url = firstMedia?.metadata?.url ?? null;
+
+  const ownerName = project.owner
+    ? `${project.owner.firstName} ${project.owner.lastName}`
+    : null;
+
+  return (
+    <>
+      <div className="flex flex-col gap-2.5">
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: Container needs hover state for video playback */}
+        <section
+          className="group relative overflow-hidden rounded-xl bg-neutral-900 aspect-video w-full"
+          onMouseEnter={() => {
+            setIsHovered(true);
+            videoRef.current?.play().catch(() => {});
+          }}
+          onMouseLeave={() => {
+            setIsHovered(false);
+            videoRef.current?.pause();
+          }}
+        >
+          {/* ── Background media ── */}
+          <div className="absolute inset-0">
+            {!url ? (
+              <div className="flex h-full w-full items-center justify-center bg-neutral-800">
+                <span className="text-xs uppercase tracking-widest text-neutral-500">
+                  No Preview
+                </span>
+              </div>
+            ) : isPdf ? (
+              <div className="flex h-full w-full flex-col items-center justify-center gap-2 bg-neutral-800">
+                <FileText size={28} className="text-neutral-400" />
+                <span className="text-xs uppercase tracking-widest text-neutral-500">
+                  PDF
+                </span>
+              </div>
+            ) : isVideo ? (
+              <video
+                ref={videoRef}
+                src={url}
+                className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.04]"
+                muted
+                playsInline
+                loop
+                preload="metadata"
+              />
+            ) : (
+              <Image
+                src={url}
+                alt={project.title}
+                fill
+                className="object-cover transition-transform duration-500 group-hover:scale-[1.04]"
+                sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+              />
+            )}
+          </div>
+
+          {/* ── Hover overlay: Eye (open modal) + Heart (unfavourite) ── */}
+          <div
+            className={`absolute inset-0 z-20 flex items-center justify-center gap-3 bg-black/55 backdrop-blur-[2px] transition-opacity duration-250 ${isHovered ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+          >
+            <button
+              type="button"
+              aria-label={`View ${project.title}`}
+              onClick={() => setModalOpen(true)}
+              className="flex items-center justify-center w-11 h-11 rounded-full bg-white/15 hover:bg-white/25 backdrop-blur-sm border border-white/25 hover:border-white/50 text-white transition-all duration-200 hover:scale-110 active:scale-95 cursor-pointer"
+            >
+              <Eye size={20} />
+            </button>
+
+            <FavouriteButton projectId={project._id} variant="overlay" />
+          </div>
+
+          {/* ── Gradient + title ── */}
+          <div className="absolute inset-0 z-10 bg-linear-to-t from-black/80 via-black/20 to-transparent pointer-events-none" />
+
+          <div className="absolute bottom-0 left-0 right-0 z-10 p-4 pointer-events-none">
+            <h3 className="font-semibold text-sm text-white line-clamp-1">
+              {project.title}
+            </h3>
+          </div>
+        </section>
+
+        {/* ── Owner attribution row (below the card, not overlapping media) ── */}
+        {project.owner && (
+          <Link
+            href={`/profile/${project.owner.username}`}
+            className="flex items-center gap-2 px-1 group/owner"
+          >
+            <div className="relative h-5 w-5 shrink-0 overflow-hidden rounded-full border border-white/15 bg-white/10">
+              {project.owner.profileImage ? (
+                <Image
+                  src={project.owner.profileImage}
+                  alt={ownerName ?? ""}
+                  fill
+                  className="object-cover"
+                />
+              ) : (
+                <span className="flex h-full w-full items-center justify-center text-[10px] font-semibold text-white/60">
+                  {project.owner.firstName.charAt(0).toUpperCase()}
+                </span>
+              )}
+            </div>
+            <span className="truncate text-xs text-white/50 group-hover/owner:text-white/80 transition-colors">
+              {ownerName} · @{project.owner.username}
+            </span>
+          </Link>
+        )}
+      </div>
+
+      <ProjectModal
+        project={project}
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+      />
+    </>
+  );
+}

--- a/app/dashboard/favourites/_components/FavouritedProjectCardSkeleton.tsx
+++ b/app/dashboard/favourites/_components/FavouritedProjectCardSkeleton.tsx
@@ -1,0 +1,11 @@
+export function FavouritedProjectCardSkeleton() {
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="aspect-video w-full rounded-xl bg-white/5 animate-pulse" />
+      <div className="flex items-center gap-2 px-1">
+        <div className="h-5 w-5 shrink-0 rounded-full bg-white/10 animate-pulse" />
+        <div className="h-3 w-32 rounded bg-white/10 animate-pulse" />
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/favourites/page.tsx
+++ b/app/dashboard/favourites/page.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { Heart, HeartCrack } from "lucide-react";
+import Link from "next/link";
+import { api } from "~/convex/_generated/api";
+import { FavouritedProjectCard } from "./_components/FavouritedProjectCard";
+import { FavouritedProjectCardSkeleton } from "./_components/FavouritedProjectCardSkeleton";
+
+const skeletonIds = [
+  "skeleton-1",
+  "skeleton-2",
+  "skeleton-3",
+  "skeleton-4",
+  "skeleton-5",
+  "skeleton-6",
+];
+
+export default function FavouritesPage() {
+  const favourites = useQuery(api.favourites.listMyFavourites);
+  const isLoading = favourites === undefined;
+
+  return (
+    <div>
+      <div className="mb-8 flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-rose-500/15 border border-rose-400/30">
+          <Heart size={18} className="text-rose-300 fill-rose-300" />
+        </div>
+        <div>
+          <h1 className="text-4xl font-semibold">Favourites</h1>
+          <p className="mt-1 text-base text-white/50">
+            Projects you have favourited across the community
+          </p>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {skeletonIds.map((id) => (
+            <FavouritedProjectCardSkeleton key={id} />
+          ))}
+        </div>
+      ) : favourites.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-white/15 bg-white/5 py-20 text-center">
+          <HeartCrack size={36} className="text-white/20" />
+          <div>
+            <p className="text-base font-medium text-white/60">
+              No favourites yet
+            </p>
+            <p className="mt-1 text-sm text-white/30">
+              Browse the community feed and heart a project to save it here.
+            </p>
+          </div>
+          <Link
+            href="/"
+            className="mt-2 inline-flex items-center gap-2 rounded-full bg-blue-500 hover:bg-blue-600 px-5 py-2.5 text-sm font-medium text-white transition-colors"
+          >
+            Browse projects
+          </Link>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {favourites.map((project) => (
+            <FavouritedProjectCard key={project._id} project={project} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/profile/[username]/_components/project.tsx
+++ b/app/profile/[username]/_components/project.tsx
@@ -2,6 +2,7 @@
 import { useQuery } from "convex/react";
 import { Calendar, ExternalLink, FileText, Video } from "lucide-react";
 import Image from "next/image";
+import { FavouriteButton } from "~/app/_components/FavouriteButton";
 import { api } from "~/convex/_generated/api";
 import { safeArray } from "~/lib/data.helpers";
 import type { Project, TimelineDate } from "~/types/models";
@@ -59,13 +60,23 @@ export default function Projects({ userId }: { userId?: string }) {
                     {project.title}
                   </h3>
 
-                  {/* Project timeline */}
-                  {project_timeline && (
-                    <div className="flex items-center gap-2.5 rounded-full border border-amber-400/30 bg-linear-to-r from-amber-500/15 to-orange-500/15 px-4 py-2 text-sm font-medium text-amber-200/90 shadow-lg">
-                      <Calendar size={16} className="text-amber-300" />
-                      <span>{project_timeline}</span>
-                    </div>
-                  )}
+                  <div className="flex flex-wrap items-center gap-2">
+                    {/* Project timeline */}
+                    {project_timeline && (
+                      <div className="flex items-center gap-2.5 rounded-full border border-amber-400/30 bg-linear-to-r from-amber-500/15 to-orange-500/15 px-4 py-2 text-sm font-medium text-amber-200/90 shadow-lg">
+                        <Calendar size={16} className="text-amber-300" />
+                        <span>{project_timeline}</span>
+                      </div>
+                    )}
+
+                    {/* Favourite button */}
+                    {project._id && (
+                      <FavouriteButton
+                        projectId={project._id}
+                        variant="inline"
+                      />
+                    )}
+                  </div>
                 </div>
 
                 {/* Project Description */}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as auth from "../auth.js";
 import type * as email from "../email.js";
+import type * as favourites from "../favourites.js";
 import type * as files from "../files.js";
 import type * as http from "../http.js";
 import type * as profiles from "../profiles.js";
@@ -27,6 +28,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   email: typeof email;
+  favourites: typeof favourites;
   files: typeof files;
   http: typeof http;
   profiles: typeof profiles;

--- a/convex/favourites.ts
+++ b/convex/favourites.ts
@@ -1,0 +1,115 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { authComponent } from "./auth";
+
+/**
+ * Toggle a project favourite for the authenticated user.
+ * Returns the new state: true = favourited, false = unfavourited.
+ */
+export const toggle = mutation({
+  args: {
+    projectId: v.id("project"),
+  },
+  handler: async (ctx, { projectId }) => {
+    const authUser = await authComponent.getAuthUser(ctx);
+    if (!authUser) throw new Error("Not authenticated");
+
+    const existing = await ctx.db
+      .query("projectFavourites")
+      .withIndex("by_userId_projectId", (q) =>
+        q.eq("userId", authUser._id).eq("projectId", projectId),
+      )
+      .unique();
+
+    if (existing) {
+      await ctx.db.delete(existing._id);
+      return false;
+    }
+
+    await ctx.db.insert("projectFavourites", {
+      userId: authUser._id,
+      projectId,
+    });
+    return true;
+  },
+});
+
+/**
+ * Get the favourite count for a project and whether the current user
+ * has favourited it (null when unauthenticated).
+ */
+export const getProjectFavourite = query({
+  args: {
+    projectId: v.id("project"),
+  },
+  handler: async (ctx, { projectId }) => {
+    const all = await ctx.db
+      .query("projectFavourites")
+      .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
+      .collect();
+
+    const count = all.length;
+
+    let isFavourited: boolean | null = null;
+    try {
+      const authUser = await authComponent.getAuthUser(ctx);
+      if (authUser) {
+        const mine = await ctx.db
+          .query("projectFavourites")
+          .withIndex("by_userId_projectId", (q) =>
+            q.eq("userId", authUser._id).eq("projectId", projectId),
+          )
+          .unique();
+        isFavourited = !!mine;
+      }
+    } catch {
+      // unauthenticated — leave null
+    }
+
+    return { count, isFavourited };
+  },
+});
+
+/**
+ * List all projects favourited by the currently authenticated user.
+ */
+export const listMyFavourites = query({
+  args: {},
+  handler: async (ctx) => {
+    const authUser = await authComponent.getAuthUser(ctx);
+    if (!authUser) return [];
+
+    const favourites = await ctx.db
+      .query("projectFavourites")
+      .withIndex("by_userId", (q) => q.eq("userId", authUser._id))
+      .order("desc")
+      .collect();
+
+    const projects = await Promise.all(
+      favourites.map(async (fav) => {
+        const project = await ctx.db.get(fav.projectId);
+        if (!project) return null;
+
+        const owner = await ctx.db
+          .query("profile")
+          .withIndex("by_userId", (q) => q.eq("userId", project.userId))
+          .unique();
+
+        return {
+          ...project,
+          favouritedAt: fav._creationTime,
+          owner: owner
+            ? {
+                firstName: owner.firstName,
+                lastName: owner.lastName,
+                username: owner.username,
+                profileImage: owner.profileImage,
+              }
+            : null,
+        };
+      }),
+    );
+
+    return projects.filter((p): p is NonNullable<typeof p> => p !== null);
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -144,6 +144,14 @@ const schema = defineSchema({
   workExperience: defineTable(work_experience_schema).index("by_userId", [
     "userId",
   ]),
+
+  projectFavourites: defineTable({
+    userId: v.string(),
+    projectId: v.id("project"),
+  })
+    .index("by_userId", ["userId"])
+    .index("by_projectId", ["projectId"])
+    .index("by_userId_projectId", ["userId", "projectId"]),
 });
 
 export default schema;


### PR DESCRIPTION
## Summary

Adds the ability to favourite/unfavourite any project across the community, with a new Convex projectFavourites table, a reusable FavouriteButton component (three variants for the landing feed, project modal, and profile cards), and a dedicated dashboard page listing everything the current user has favourited.

## Related Issue

Closes #78

## Type of Change

<!-- Check the one that applies -->

- [ ] Bug fix (fixes an issue without breaking existing functionality)
- [x] New feature (adds functionality without breaking existing behaviour)
- [ ] Breaking change (existing functionality changes or is removed)
- [ ] Documentation update (README, CONTRIBUTING, templates, etc.)
- [ ] Refactor (code restructuring, no behaviour changes)
- [ ] Test (adding or updating tests only)
- [ ] Chore (dependency update, config change, tooling)

## What Changed

- Added projectFavourites table to the Convex schema with by_userId, by_projectId, and by_userId_projectId indexes for O(1) lookups
- Added convex/favourites.ts with toggle, getProjectFavourite, and listMyFavourites — the list query also joins each favourite to its project owner's profile so the dashboard can show whose project it is
- Added FavouriteButton, a shared component with three variants (overlay for the hover state on cards, card for the project modal, inline for profile project rows), built with useOptimistic so the heart and count update instantly before the mutation resolves
- Extracted MediaThumb and ProjectModal out of LandingProjectCard into standalone shared components so the landing feed card and the new dashboard favourites card render an identical modal without duplicated logic
- Reworked LandingProjectCard so the card is no longer one giant click target — hovering now reveals a scrim with a separate Eye button (opens the modal) and Heart button (toggles favourite) side by side
- Added app/dashboard/favourites/page.tsx with a grid of favourited projects, an empty state pointing back to the community feed, and a loading skeleton
- Added FavouritedProjectCard, which mirrors the landing card's hover pattern and adds an owner attribution row (avatar, name, @username) linking to that person's profile
- Added a "Favourites" entry to the dashboard sidebar between Projects and Settings
- Added FavouriteButton to the existing profile project cards (app/profile/[username]/_components/project.tsx)
