### PR TITLE
fix(auth): prevent duplicate toast notifications

### DIFF
--- a/__tests__/toast-provider.test.ts
+++ b/__tests__/toast-provider.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("global toast provider", () => {
+  it("mounts one Sonner Toaster across the root layout and providers", () => {
+    const rootFiles = ["app/layout.tsx", "app/providers.tsx"];
+    const mountCount = rootFiles.reduce((count, file) => {
+      const source = readFileSync(resolve(process.cwd(), file), "utf8");
+      return count + (source.match(/<Toaster\b/g)?.length ?? 0);
+    }, 0);
+
+    expect(mountCount).toBe(1);
+  });
+});

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import "./globals.css";
 import type { Metadata } from "next";
-import { Toaster } from "sonner";
 import { getToken } from "~/lib/auth-server";
 import NavAuth from "./_components/NavAuth";
 import Providers from "./providers";
@@ -34,7 +33,6 @@ export default async function RootLayout({ children }) {
             {children}
           </body>
         </html>
-        <Toaster position="top-right" />
       </Providers>
     </NuqsAdapter>
   );


### PR DESCRIPTION
## Summary

- remove the duplicate root-layout Sonner `Toaster`
- keep the single shared toaster already mounted by `Providers`
- add a regression test that enforces one global toaster mount across the root layout and provider shell

## Root cause

Both `app/layout.tsx` and `app/providers.tsx` mounted a global Sonner `Toaster`. A single successful sign-in toast was therefore rendered by two containers.

## Validation

- `bun test` (2 tests passed)
- `bun run lint` (Biome + TypeScript passed)
- `bun x prettier --check app/layout.tsx __tests__/toast-provider.test.ts`
- `bun run build` with non-secret placeholder Convex URLs (production build passed)
- `git diff --check`

Dependency audit was also run. It reports pre-existing advisories in the repository dependency tree; this PR does not change dependencies.

Closes #109