### PR TITLE
fix(auth): hide actions until session resolves

### DIFF
--- a/__tests__/nav-auth.test.tsx
+++ b/__tests__/nav-auth.test.tsx
@@ -1,0 +1,50 @@
+import { cleanup, render, screen } from "@testing-library/react";
+
+const { useSession } = vi.hoisted(() => ({ useSession: vi.fn() }));
+
+vi.mock("~/lib/auth-client", () => ({
+  authClient: { useSession },
+}));
+
+import NavAuth from "~/app/_components/NavAuth";
+
+describe("NavAuth", () => {
+  afterEach(() => {
+    cleanup();
+    useSession.mockReset();
+  });
+
+  it("renders no auth actions while the session is loading", () => {
+    useSession.mockReturnValue({ data: null, isPending: true });
+
+    render(<NavAuth />);
+
+    expect(screen.queryByText("Sign In")).toBeNull();
+    expect(screen.queryByText("Sign Up")).toBeNull();
+  });
+
+  it("renders auth actions after an unauthenticated session resolves", () => {
+    useSession.mockReturnValue({ data: null, isPending: false });
+
+    render(<NavAuth />);
+
+    expect(screen.getByText("Sign In").getAttribute("href")).toBe("/auth");
+    expect(screen.getByText("Sign Up").getAttribute("href")).toBe(
+      "/auth?mode=sign-up",
+    );
+  });
+
+  it("renders the user dashboard link for an authenticated session", () => {
+    useSession.mockReturnValue({
+      data: { user: { name: "Nightmore" } },
+      isPending: false,
+    });
+
+    render(<NavAuth />);
+
+    expect(screen.queryByText("Sign In")).toBeNull();
+    expect(
+      screen.getByRole("link", { name: "Go to dashboard" }).textContent,
+    ).toBe("N");
+  });
+});

--- a/app/_components/NavAuth.tsx
+++ b/app/_components/NavAuth.tsx
@@ -1,11 +1,14 @@
+"use client";
+
 import Link from "next/link";
-import { fetchAuthQuery, isAuthenticated } from "@/lib/auth-server";
-import { api } from "~/convex/_generated/api";
+import { authClient } from "~/lib/auth-client";
 
-export default async function NavAuth() {
-  const authenticated = await isAuthenticated();
+export default function NavAuth() {
+  const { data: session, isPending } = authClient.useSession();
 
-  if (!authenticated) {
+  if (isPending) return null;
+
+  if (!session) {
     return (
       <>
         <Link
@@ -24,8 +27,7 @@ export default async function NavAuth() {
     );
   }
 
-  const user = await fetchAuthQuery(api.auth.getCurrentUser).catch(() => null);
-  const initial = user?.name?.charAt(0)?.toUpperCase() ?? "U";
+  const initial = session.user.name?.charAt(0)?.toUpperCase() ?? "U";
 
   return (
     <Link


### PR DESCRIPTION
## Summary

- make `NavAuth` consume the existing Better Auth client session
- render no sign-in/sign-up actions while session hydration is pending
- render auth links only after an unauthenticated result, and the dashboard avatar for an authenticated result
- cover pending, unauthenticated, and authenticated states with component tests

## Root cause

`NavAuth` was an async server component inside the persistent root layout. After client-side authentication, that layout could continue showing the unauthenticated server result. The component also had no pending session state, so auth actions were shown before the client session resolved.

## Validation

- `bun run test` (4 tests passed)
- `bun run lint` (Biome + TypeScript passed)
- `bun x prettier --check app/_components/NavAuth.tsx __tests__/nav-auth.test.tsx`
- `npx lint-staged`
- `bun run build` with non-secret placeholder Convex URLs (production build passed)
- `git diff --check`

The repository dependency audit findings are unchanged; this PR does not modify dependencies.

Closes #110